### PR TITLE
Make When::some() and When::any() more deterministic and consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,11 @@ $promise = React\Promise\When::any(array|React\Promise\PromiseInterface $promise
 ```
 
 Returns a Promise that will resolve when any one of the items in
-`$promisesOrValues` has resolved. The resolution value of the returned Promise
+`$promisesOrValues` resolves. The resolution value of the returned Promise
 will be the resolution value of the triggering item.
+
+The returned Promise will only reject if *all* items in `$promisesOrValues` are
+rejected. The rejection value will be an array of all rejection reasons.
 
 #### When::some()
 
@@ -202,9 +205,14 @@ $promise = React\Promise\When::some(array|React\Promise\PromiseInterface $promis
 ```
 
 Returns a Promise that will resolve when `$howMany` of the supplied items in
-`$promisesOrValues` have resolved. The resolution value of the returned Promise
+`$promisesOrValues` resolve. The resolution value of the returned Promise
 will be an array of length `$howMany` containing the resolution values of the
 triggering items.
+
+The returned Promise will reject if it becomes impossible for `$howMany` items
+to resolve (that is, when `(count($promisesOrValues) - $howMany) + 1` items
+reject). The rejection value will be an array of
+`(count($promisesOrValues) - $howMany) + 1` rejection reasons.
 
 #### When::map()
 

--- a/tests/React/Promise/WhenAnyTest.php
+++ b/tests/React/Promise/WhenAnyTest.php
@@ -51,16 +51,16 @@ class WhenAnyTest extends TestCase
     }
 
     /** @test */
-    public function shouldRejectWithARejectedInputValue()
+    public function shouldRejectWithAllRejectedInputValuesIfAllInputsAreRejected()
     {
         $mock = $this->createCallableMock();
         $mock
             ->expects($this->once())
             ->method('__invoke')
-            ->with($this->identicalTo(1));
+            ->with($this->identicalTo(array(0 => 1, 1 => 2, 2 => 3)));
 
-        When::all(
-            array(new RejectedPromise(1), new ResolvedPromise(2), new ResolvedPromise(3)),
+        When::any(
+            array(new RejectedPromise(1), new RejectedPromise(2), new RejectedPromise(3)),
             $this->expectCallableNever(),
             $mock
         );

--- a/tests/React/Promise/WhenSomeTest.php
+++ b/tests/React/Promise/WhenSomeTest.php
@@ -75,10 +75,10 @@ class WhenSomeTest extends TestCase
         $mock
             ->expects($this->once())
             ->method('__invoke')
-            ->with($this->identicalTo(2));
+            ->with($this->identicalTo(array(1 => 2, 2 => 3)));
 
         When::some(
-            array(new ResolvedPromise(1), new RejectedPromise(2), new ResolvedPromise(3)),
+            array(new ResolvedPromise(1), new RejectedPromise(2), new RejectedPromise(3)),
             2,
             $this->expectCallableNever(),
             $mock


### PR DESCRIPTION
This basically syncs with changes from when.js. Read [this issue](https://github.com/cujojs/when/issues/60) for more information.
