### PR TITLE
Adding a return tag to interfaces.

### DIFF
--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -4,5 +4,8 @@ namespace React\Promise;
 
 interface PromiseInterface
 {
+    /**
+     * @return PromiseInterface
+     */
     public function then(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null);
 }

--- a/src/PromisorInterface.php
+++ b/src/PromisorInterface.php
@@ -4,5 +4,8 @@ namespace React\Promise;
 
 interface PromisorInterface
 {
+    /**
+     * @return PromiseInterface
+     */
     public function promise();
 }


### PR DESCRIPTION
Interfaces should describe a contract. The contract is not
specified in the interface unless there is a docblock with
an `@return` tag to tell implementations what should be
returned. While this information is provided in the docs,
it should also be available on the interfaces.
