### PR TITLE
1.1 release for 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
 before_script:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ php:
   - 7.0
   - hhvm
 
-before_script:
-  - composer install
+before_install:
+  - composer self-update
 
-script: phpunit --coverage-text
+install:
+  - composer install --prefer-source
+
+script:
+  - phpunit -v --coverage-text

--- a/README.md
+++ b/README.md
@@ -343,8 +343,7 @@ value.
 The `React\Promise\When` class provides useful methods for creating, joining,
 mapping and reducing collections of Promises.
 
-    **Note:** Since version 1.1 `React\Promise\When` acts only as a proxy for
-    the [Promise functions](#functions) and its usage is discouraged.
+> **Note:** Since version 1.1 `React\Promise\When` acts only as a proxy for the [Promise functions](#functions) and its usage is discouraged.
 
 #### When::all()
 
@@ -352,8 +351,7 @@ mapping and reducing collections of Promises.
 $promise = React\Promise\When::all(array|React\Promise\PromiseInterface $promisesOrValues, callable $fulfilledHandler = null, callable $errorHandler = null, callable $progressHandler = null);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\all()`](#all) is preferred
-    over `React\Promise\When::all()`.
+> **Note:** Since version 1.1, [`React\Promise\all()`](#all) is preferred over `React\Promise\When::all()`.
     
 Returns a Promise that will resolve only once all the items in
 `$promisesOrValues` have resolved. The resolution value of the returned Promise
@@ -366,8 +364,7 @@ will be an array containing the resolution values of each of the items in
 $promise = React\Promise\When::any(array|React\Promise\PromiseInterface $promisesOrValues, callable $fulfilledHandler = null, callable $errorHandler = null, callable $progressHandler = null);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\any()`](#any) is preferred
-    over `React\Promise\When::any()`.
+> **Note:** Since version 1.1, [`React\Promise\any()`](#any) is preferred over `React\Promise\When::any()`.
     
 Returns a Promise that will resolve when any one of the items in
 `$promisesOrValues` resolves. The resolution value of the returned Promise
@@ -382,8 +379,7 @@ rejected. The rejection value will be an array of all rejection reasons.
 $promise = React\Promise\When::some(array|React\Promise\PromiseInterface $promisesOrValues, integer $howMany, callable $fulfilledHandler = null, callable $errorHandler = null, callable $progressHandler = null);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\some()`](#some) is preferred
-    over `React\Promise\When::some()`.
+> **Note:** Since version 1.1, [`React\Promise\some()`](#some) is preferred over `React\Promise\When::some()`.
     
 Returns a Promise that will resolve when `$howMany` of the supplied items in
 `$promisesOrValues` resolve. The resolution value of the returned Promise
@@ -401,8 +397,7 @@ reject). The rejection value will be an array of
 $promise = React\Promise\When::map(array|React\Promise\PromiseInterface $promisesOrValues, callable $mapFunc);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\map()`](#map) is preferred
-    over `React\Promise\When::map()`.
+> **Note:** Since version 1.1, [`React\Promise\map()`](#map) is preferred over `React\Promise\When::map()`.
     
 Traditional map function, similar to `array_map()`, but allows input to contain
 Promises and/or values, and `$mapFunc` may return either a value or a Promise.
@@ -416,8 +411,7 @@ value of a Promise or value in `$promisesOrValues`.
 $promise = React\Promise\When::reduce(array|React\Promise\PromiseInterface $promisesOrValues, callable $reduceFunc , $initialValue = null);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\reduce()`](#reduce) is preferred
-    over `React\Promise\When::reduce()`.
+> **Note:** Since version 1.1, [`React\Promise\reduce()`](#reduce) is preferred over `React\Promise\When::reduce()`.
     
 Traditional reduce function, similar to `array_reduce()`, but input may contain
 Promises and/or values, and `$reduceFunc` may return either a value or a
@@ -430,8 +424,7 @@ value.
 $promise = React\Promise\When::resolve(mixed $promiseOrValue);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\resolve()`](#resolve) is preferred
-    over `React\Promise\When::resolve()`.
+> **Note:** Since version 1.1, [`React\Promise\resolve()`](#resolve) is preferred over `React\Promise\When::resolve()`.
     
 Creates a resolved Promise for the supplied `$promiseOrValue`.
 
@@ -446,8 +439,7 @@ If `$promiseOrValue` is a Promise, it will simply be returned.
 $promise = React\Promise\When::reject(mixed $promiseOrValue);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\reject()`](#reject) is preferred
-    over `React\Promise\When::reject()`.
+> **Note:** Since version 1.1, [`React\Promise\reject()`](#reject) is preferred over `React\Promise\When::reject()`.
     
 Creates a rejected Promise for the supplied `$promiseOrValue`.
 
@@ -467,8 +459,7 @@ the value of another Promise.
 $promise = React\Promise\When::lazy(callable $factory);
 ```
 
-    **Note:** Since version 1.1, [`React\Promise\lazy()`](#lazy) is preferred
-    over `React\Promise\When::lazy()`.
+> **Note:** Since version 1.1, [`React\Promise\lazy()`](#lazy) is preferred over `React\Promise\When::lazy()`.
     
 Creates a Promise which will be lazily initialized by `$factory` once a consumer
 calls the `then()` method.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Table of Contents
    * [Deferred](#deferred-1)
    * [Promise](#promise-1)
    * [Resolver](#resolver-1)
+   * [Functions](#functions)
+     * [resolve()](#resolve)
+     * [reject()](#reject)
+     * [all()](#all)
+     * [race()](#race)
+     * [any()](#any)
+     * [some()](#some)
+     * [map()](#map)
+     * [reduce()](#reduce)
    * [When](#when)
      * [When::all()](#whenall)
      * [When::any()](#whenany)
@@ -109,6 +118,38 @@ The Promise represents the eventual outcome, which is either fulfillment
 reason. The Promise provides mechanisms for arranging to call a function on its
 value or reason, and produces a new Promise for the result.
 
+Creates a promise whose state is controlled by the functions passed to
+`$resolver`.
+
+```php
+$resolver = function (callable $resolve, callable $reject, callable $notify) {
+    // Do some work, possibly asynchronously, and then
+    // resolve or reject. You can notify of progress events
+    // along the way if you want/need.
+
+    $resolve($awesomeResult);
+    // or $resolve($anotherPromise);
+    // or $reject($nastyError);
+    // or $notify($progressNotification);
+};
+
+$promise = new React\Promise\Promise($resolver);
+```
+
+The promise constructor receives a resolver function which will be called
+immediately with 3 arguments:
+
+  * `$resolve($value)` - Primary function that seals the fate of the
+    returned promise. Accepts either a non-promise value, or another promise.
+    When called with a non-promise value, fulfills promise with that value.
+    When called with another promise, e.g. `$resolve($otherPromise)`, promise's
+    fate will be equivalent to that of `$otherPromise`.
+  * `$reject($reason)` - Function that rejects the promise.
+  * `$notify($update)` - Function that issues progress events for the promise.
+
+If the resolver throws an exception, the promise will be rejected with that
+thrown exception as the rejection reason.
+
 A Promise has a single method `then()` which registers new fulfilled, error and
 progress handlers with this Promise (all parameters are optional):
 
@@ -184,10 +225,126 @@ is making progress toward its result.
 All consumers are notified by having their `$progressHandler` (which they
 registered via `$promise->then()`) called with `$update`.
 
+### Functions
+
+Useful functions for creating, joining, mapping and reducing collections of
+promises.
+
+#### resolve()
+
+```php
+$promise = React\Promise\resolve(mixed $promiseOrValue);
+```
+
+Creates a promise for the supplied `$promiseOrValue`.
+
+If `$promiseOrValue` is a value, it will be the resolution value of the
+returned promise.
+
+If `$promiseOrValue` is a promise, it will simply be returned.
+
+Note: The promise returned is always a promise implementing
+[ExtendedPromiseInterface](#extendedpromiseinterface). If you pass in a custom
+promise which only implements [PromiseInterface](#promiseinterface), this
+promise will be assimilated to a extended promise following `$promiseOrValue`.
+
+#### reject()
+
+```php
+$promise = React\Promise\reject(mixed $promiseOrValue);
+```
+
+Creates a rejected promise for the supplied `$promiseOrValue`.
+
+If `$promiseOrValue` is a value, it will be the rejection value of the
+returned promise.
+
+If `$promiseOrValue` is a promise, its completion value will be the rejected
+value of the returned promise.
+
+This can be useful in situations where you need to reject a promise without
+throwing an exception. For example, it allows you to propagate a rejection with
+the value of another promise.
+
+#### all()
+
+```php
+$promise = React\Promise\all(array|React\Promise\PromiseInterface $promisesOrValues);
+```
+
+Returns a promise that will resolve only once all the items in
+`$promisesOrValues` have resolved. The resolution value of the returned promise
+will be an array containing the resolution values of each of the items in
+`$promisesOrValues`.
+
+#### race()
+
+```php
+$promise = React\Promise\race(array|React\Promise\PromiseInterface $promisesOrValues);
+```
+
+Initiates a competitive race that allows one winner. Returns a promise which is
+resolved in the same way the first settled promise resolves.
+
+#### any()
+
+```php
+$promise = React\Promise\any(array|React\Promise\PromiseInterface $promisesOrValues);
+```
+
+Returns a promise that will resolve when any one of the items in
+`$promisesOrValues` resolves. The resolution value of the returned promise
+will be the resolution value of the triggering item.
+
+The returned promise will only reject if *all* items in `$promisesOrValues` are
+rejected. The rejection value will be an array of all rejection reasons.
+
+#### some()
+
+```php
+$promise = React\Promise\some(array|React\Promise\PromiseInterface $promisesOrValues, integer $howMany);
+```
+
+Returns a promise that will resolve when `$howMany` of the supplied items in
+`$promisesOrValues` resolve. The resolution value of the returned promise
+will be an array of length `$howMany` containing the resolution values of the
+triggering items.
+
+The returned promise will reject if it becomes impossible for `$howMany` items
+to resolve (that is, when `(count($promisesOrValues) - $howMany) + 1` items
+reject). The rejection value will be an array of
+`(count($promisesOrValues) - $howMany) + 1` rejection reasons.
+
+#### map()
+
+```php
+$promise = React\Promise\map(array|React\Promise\PromiseInterface $promisesOrValues, callable $mapFunc);
+```
+
+Traditional map function, similar to `array_map()`, but allows input to contain
+promises and/or values, and `$mapFunc` may return either a value or a promise.
+
+The map function receives each item as argument, where item is a fully resolved
+value of a promise or value in `$promisesOrValues`.
+
+#### reduce()
+
+```php
+$promise = React\Promise\reduce(array|React\Promise\PromiseInterface $promisesOrValues, callable $reduceFunc , $initialValue = null);
+```
+
+Traditional reduce function, similar to `array_reduce()`, but input may contain
+promises and/or values, and `$reduceFunc` may return either a value or a
+promise, *and* `$initialValue` may be a promise or a value for the starting
+value.
+
 ### When
 
 The `React\Promise\When` class provides useful methods for creating, joining,
 mapping and reducing collections of Promises.
+
+    **Note:** Since version 1.1 `React\Promise\When` acts only as a proxy for
+    the [Promise functions](#functions) and its usage is discouraged.
 
 #### When::all()
 
@@ -195,6 +352,9 @@ mapping and reducing collections of Promises.
 $promise = React\Promise\When::all(array|React\Promise\PromiseInterface $promisesOrValues, callable $fulfilledHandler = null, callable $errorHandler = null, callable $progressHandler = null);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\all()`](#all) is preferred
+    over `React\Promise\When::all()`.
+    
 Returns a Promise that will resolve only once all the items in
 `$promisesOrValues` have resolved. The resolution value of the returned Promise
 will be an array containing the resolution values of each of the items in
@@ -206,6 +366,9 @@ will be an array containing the resolution values of each of the items in
 $promise = React\Promise\When::any(array|React\Promise\PromiseInterface $promisesOrValues, callable $fulfilledHandler = null, callable $errorHandler = null, callable $progressHandler = null);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\any()`](#any) is preferred
+    over `React\Promise\When::any()`.
+    
 Returns a Promise that will resolve when any one of the items in
 `$promisesOrValues` resolves. The resolution value of the returned Promise
 will be the resolution value of the triggering item.
@@ -219,6 +382,9 @@ rejected. The rejection value will be an array of all rejection reasons.
 $promise = React\Promise\When::some(array|React\Promise\PromiseInterface $promisesOrValues, integer $howMany, callable $fulfilledHandler = null, callable $errorHandler = null, callable $progressHandler = null);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\some()`](#some) is preferred
+    over `React\Promise\When::some()`.
+    
 Returns a Promise that will resolve when `$howMany` of the supplied items in
 `$promisesOrValues` resolve. The resolution value of the returned Promise
 will be an array of length `$howMany` containing the resolution values of the
@@ -235,6 +401,9 @@ reject). The rejection value will be an array of
 $promise = React\Promise\When::map(array|React\Promise\PromiseInterface $promisesOrValues, callable $mapFunc);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\map()`](#map) is preferred
+    over `React\Promise\When::map()`.
+    
 Traditional map function, similar to `array_map()`, but allows input to contain
 Promises and/or values, and `$mapFunc` may return either a value or a Promise.
 
@@ -247,6 +416,9 @@ value of a Promise or value in `$promisesOrValues`.
 $promise = React\Promise\When::reduce(array|React\Promise\PromiseInterface $promisesOrValues, callable $reduceFunc , $initialValue = null);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\reduce()`](#reduce) is preferred
+    over `React\Promise\When::reduce()`.
+    
 Traditional reduce function, similar to `array_reduce()`, but input may contain
 Promises and/or values, and `$reduceFunc` may return either a value or a
 Promise, *and* `$initialValue` may be a Promise or a value for the starting
@@ -258,6 +430,9 @@ value.
 $promise = React\Promise\When::resolve(mixed $promiseOrValue);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\resolve()`](#resolve) is preferred
+    over `React\Promise\When::resolve()`.
+    
 Creates a resolved Promise for the supplied `$promiseOrValue`.
 
 If `$promiseOrValue` is a value, it will be the resolution value of the
@@ -271,6 +446,9 @@ If `$promiseOrValue` is a Promise, it will simply be returned.
 $promise = React\Promise\When::reject(mixed $promiseOrValue);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\reject()`](#reject) is preferred
+    over `React\Promise\When::reject()`.
+    
 Creates a rejected Promise for the supplied `$promiseOrValue`.
 
 If `$promiseOrValue` is a value, it will be the rejection value of the
@@ -289,6 +467,9 @@ the value of another Promise.
 $promise = React\Promise\When::lazy(callable $factory);
 ```
 
+    **Note:** Since version 1.1, [`React\Promise\lazy()`](#lazy) is preferred
+    over `React\Promise\When::lazy()`.
+    
 Creates a Promise which will be lazily initialized by `$factory` once a consumer
 calls the `then()` method.
 

--- a/README.md
+++ b/README.md
@@ -459,8 +459,6 @@ the value of another Promise.
 $promise = React\Promise\When::lazy(callable $factory);
 ```
 
-> **Note:** Since version 1.1, [`React\Promise\lazy()`](#lazy) is preferred over `React\Promise\When::lazy()`.
-    
 Creates a Promise which will be lazily initialized by `$factory` once a consumer
 calls the `then()` method.
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A lightweight implementation of CommonJS Promises/A for PHP",
     "license": "MIT",
     "authors": [
-        {"name": "Jan Sorgalla", "email": "jsorgalla@googlemail.com"}
+        {"name": "Jan Sorgalla", "email": "jsorgalla@gmail.com"}
     ],
     "require": {
         "php": ">=5.3.3"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "autoload": {
         "psr-0": {
             "React\\Promise": "src/"
-        }
+        },
+        "files": ["src/React/Promise/functions.php"]
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-0": {
             "React\\Promise": "src/"
         },
-        "files": ["src/React/Promise/functions.php"]
+        "files": ["src/React/Promise/functions_include.php"]
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }

--- a/src/React/Promise/Deferred.php
+++ b/src/React/Promise/Deferred.php
@@ -52,10 +52,10 @@ class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface
     public function resolve($result = null)
     {
         if (null !== $this->completed) {
-            return Util::promiseFor($result);
+            return resolve($result);
         }
 
-        $this->completed = Util::promiseFor($result);
+        $this->completed = resolve($result);
 
         $this->processQueue($this->handlers, $this->completed);
 
@@ -66,7 +66,7 @@ class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface
 
     public function reject($reason = null)
     {
-        return $this->resolve(Util::rejectedPromiseFor($reason));
+        return $this->resolve(reject($reason));
     }
 
     public function progress($update = null)

--- a/src/React/Promise/FulfilledPromise.php
+++ b/src/React/Promise/FulfilledPromise.php
@@ -22,7 +22,7 @@ class FulfilledPromise implements PromiseInterface
                 trigger_error('Invalid $fulfilledHandler argument passed to then(), must be null or callable.', E_USER_NOTICE);
             }
 
-            return Util::promiseFor($result);
+            return resolve($result);
         } catch (\Exception $exception) {
             return new RejectedPromise($exception);
         }

--- a/src/React/Promise/LazyPromise.php
+++ b/src/React/Promise/LazyPromise.php
@@ -16,7 +16,7 @@ class LazyPromise implements PromiseInterface
     {
         if (null === $this->promise) {
             try {
-                $this->promise = Util::promiseFor(call_user_func($this->factory));
+                $this->promise = resolve(call_user_func($this->factory));
             } catch (\Exception $exception) {
                 $this->promise = new RejectedPromise($exception);
             }

--- a/src/React/Promise/Promise.php
+++ b/src/React/Promise/Promise.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace React\Promise;
+
+class Promise implements PromiseInterface
+{
+    private $deferred;
+
+    public function __construct($resolver, $canceller = null)
+    {
+        if (!is_callable($resolver)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'The resolver arguments must be of type callable, %s given.',
+                    gettype($resolver)
+                )
+            );
+        }
+
+        $this->deferred = new Deferred();
+        $this->call($resolver);
+    }
+
+    public function then($fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
+    {
+        return $this->deferred->then($fulfilledHandler, $errorHandler, $progressHandler);
+    }
+
+    private function call($callback)
+    {
+        try {
+            $callback(
+                array($this->deferred, 'resolve'),
+                array($this->deferred, 'reject'),
+                array($this->deferred, 'progress')
+            );
+        } catch (\Exception $e) {
+            $this->deferred->reject($e);
+        }
+    }
+}

--- a/src/React/Promise/Promise.php
+++ b/src/React/Promise/Promise.php
@@ -29,7 +29,8 @@ class Promise implements PromiseInterface
     private function call($callback)
     {
         try {
-            $callback(
+            call_user_func(
+                $callback,
                 array($this->deferred, 'resolve'),
                 array($this->deferred, 'reject'),
                 array($this->deferred, 'progress')

--- a/src/React/Promise/Promise.php
+++ b/src/React/Promise/Promise.php
@@ -6,7 +6,7 @@ class Promise implements PromiseInterface
 {
     private $deferred;
 
-    public function __construct($resolver, $canceller = null)
+    public function __construct($resolver)
     {
         if (!is_callable($resolver)) {
             throw new \InvalidArgumentException(

--- a/src/React/Promise/Promise.php
+++ b/src/React/Promise/Promise.php
@@ -11,7 +11,7 @@ class Promise implements PromiseInterface
         if (!is_callable($resolver)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    'The resolver arguments must be of type callable, %s given.',
+                    'The resolver argument must be of type callable, %s given.',
                     gettype($resolver)
                 )
             );

--- a/src/React/Promise/Promise.php
+++ b/src/React/Promise/Promise.php
@@ -28,12 +28,20 @@ class Promise implements PromiseInterface
 
     private function call($callback)
     {
+        $deferred = $this->deferred;
+
         try {
             call_user_func(
                 $callback,
-                array($this->deferred, 'resolve'),
-                array($this->deferred, 'reject'),
-                array($this->deferred, 'progress')
+                function ($result = null) use ($deferred) {
+                    $deferred->resolve($result);
+                },
+                function ($reason = null) use ($deferred) {
+                    $deferred->reject($reason);
+                },
+                function ($update = null) use ($deferred) {
+                    $deferred->progress($update);
+                }
             );
         } catch (\Exception $e) {
             $this->deferred->reject($e);

--- a/src/React/Promise/RejectedPromise.php
+++ b/src/React/Promise/RejectedPromise.php
@@ -22,7 +22,7 @@ class RejectedPromise implements PromiseInterface
                 return new RejectedPromise($this->reason);
             }
 
-            return Util::promiseFor(call_user_func($errorHandler, $this->reason));
+            return resolve(call_user_func($errorHandler, $this->reason));
         } catch (\Exception $exception) {
             return new RejectedPromise($exception);
         }

--- a/src/React/Promise/Util.php
+++ b/src/React/Promise/Util.php
@@ -6,21 +6,11 @@ class Util
 {
     public static function promiseFor($promiseOrValue)
     {
-        if ($promiseOrValue instanceof PromiseInterface) {
-            return $promiseOrValue;
-        }
-
-        return new FulfilledPromise($promiseOrValue);
+        return resolve($promiseOrValue);
     }
 
     public static function rejectedPromiseFor($promiseOrValue)
     {
-        if ($promiseOrValue instanceof PromiseInterface) {
-            return $promiseOrValue->then(function ($value) {
-                return new RejectedPromise($value);
-            });
-        }
-
-        return new RejectedPromise($promiseOrValue);
+        return reject($promiseOrValue);
     }
 }

--- a/src/React/Promise/When.php
+++ b/src/React/Promise/When.php
@@ -30,13 +30,11 @@ class When
 
     public static function any($promisesOrValues, $fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
     {
-        $unwrapSingleResult = function ($val) use ($fulfilledHandler) {
-            $val = array_shift($val);
+        $promise =  static::some($promisesOrValues, 1)->then(function($val) {
+            return array_shift($val);
+        });
 
-            return $fulfilledHandler ? $fulfilledHandler($val) : $val;
-        };
-
-        return static::some($promisesOrValues, 1, $unwrapSingleResult, $errorHandler, $progressHandler);
+        return $promise->then($fulfilledHandler, $errorHandler, $progressHandler);
     }
 
     public static function some($promisesOrValues, $howMany, $fulfilledHandler = null, $errorHandler = null, $progressHandler = null)

--- a/src/React/Promise/When.php
+++ b/src/React/Promise/When.php
@@ -6,12 +6,12 @@ class When
 {
     public static function resolve($promiseOrValue = null)
     {
-        return Util::promiseFor($promiseOrValue);
+        return resolve($promiseOrValue);
     }
 
     public static function reject($promiseOrValue = null)
     {
-        return Util::rejectedPromiseFor($promiseOrValue);
+        return reject($promiseOrValue);
     }
 
     public static function lazy($factory)
@@ -21,146 +21,26 @@ class When
 
     public static function all($promisesOrValues, $fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
     {
-        $promise = static::map($promisesOrValues, function ($val) {
-            return $val;
-        });
-
-        return $promise->then($fulfilledHandler, $errorHandler, $progressHandler);
+        return all($promisesOrValues)->then($fulfilledHandler, $errorHandler, $progressHandler);
     }
 
     public static function any($promisesOrValues, $fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
     {
-        $promise =  static::some($promisesOrValues, 1)->then(function($val) {
-            return array_shift($val);
-        });
-
-        return $promise->then($fulfilledHandler, $errorHandler, $progressHandler);
+        return any($promisesOrValues)->then($fulfilledHandler, $errorHandler, $progressHandler);
     }
 
     public static function some($promisesOrValues, $howMany, $fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
     {
-        return When::resolve($promisesOrValues)->then(function ($array) use ($howMany, $fulfilledHandler, $errorHandler, $progressHandler) {
-            if (!is_array($array)) {
-                $array = array();
-            }
-
-            $len       = count($array);
-            $toResolve = max(0, min($howMany, $len));
-            $values    = array();
-            $deferred  = new Deferred();
-
-            if (!$toResolve) {
-                $deferred->resolve($values);
-            } else {
-                $toReject = ($len - $toResolve) + 1;
-                $reasons  = array();
-
-                $progress = array($deferred, 'progress');
-
-                $fulfillOne = function ($val, $i) use (&$values, &$toResolve, $deferred) {
-                    $values[$i] = $val;
-
-                    if (0 === --$toResolve) {
-                        $deferred->resolve($values);
-
-                        return true;
-                    }
-                };
-
-                $rejectOne = function ($reason, $i) use (&$reasons, &$toReject, $deferred) {
-                    $reasons[$i] = $reason;
-
-                    if (0 === --$toReject) {
-                        $deferred->reject($reasons);
-
-                        return true;
-                    }
-                };
-
-                foreach ($array as $i => $promiseOrValue) {
-                    $fulfiller = function ($val) use ($i, &$fulfillOne, &$rejectOne) {
-                        $reset = $fulfillOne($val, $i);
-
-                        if (true === $reset) {
-                            $fulfillOne = $rejectOne = function () {};
-                        }
-                    };
-
-                    $rejecter = function ($val) use ($i, &$fulfillOne, &$rejectOne) {
-                        $reset = $rejectOne($val, $i);
-
-                        if (true === $reset) {
-                            $fulfillOne = $rejectOne = function () {};
-                        }
-                    };
-
-                    When::resolve($promiseOrValue)->then($fulfiller, $rejecter, $progress);
-                }
-            }
-
-            return $deferred->then($fulfilledHandler, $errorHandler, $progressHandler);
-        });
+        return some($promisesOrValues, $howMany)->then($fulfilledHandler, $errorHandler, $progressHandler);
     }
 
     public static function map($promisesOrValues, $mapFunc)
     {
-        return When::resolve($promisesOrValues)->then(function ($array) use ($mapFunc) {
-            if (!is_array($array)) {
-                $array = array();
-            }
-
-            $toResolve = count($array);
-            $results   = array();
-            $deferred  = new Deferred();
-
-            if (!$toResolve) {
-                $deferred->resolve($results);
-            } else {
-                $resolve = function ($item, $i) use ($mapFunc, &$results, &$toResolve, $deferred) {
-                    When::resolve($item)
-                        ->then($mapFunc)
-                        ->then(
-                            function ($mapped) use (&$results, $i, &$toResolve, $deferred) {
-                                $results[$i] = $mapped;
-
-                                if (0 === --$toResolve) {
-                                    $deferred->resolve($results);
-                                }
-                            },
-                            array($deferred, 'reject')
-                        );
-                };
-
-                foreach ($array as $i => $item) {
-                    $resolve($item, $i);
-                }
-            }
-
-            return $deferred->promise();
-        });
+        return map($promisesOrValues, $mapFunc);
     }
 
     public static function reduce($promisesOrValues, $reduceFunc , $initialValue = null)
     {
-        return When::resolve($promisesOrValues)->then(function ($array) use ($reduceFunc, $initialValue) {
-            if (!is_array($array)) {
-                $array = array();
-            }
-
-            $total = count($array);
-            $i = 0;
-
-            // Wrap the supplied $reduceFunc with one that handles promises and then
-            // delegates to the supplied.
-            $wrappedReduceFunc = function ($current, $val) use ($reduceFunc, $total, &$i) {
-                return When::resolve($current)->then(function ($c) use ($reduceFunc, $total, &$i, $val) {
-                    return When::resolve($val)->then(function ($value) use ($reduceFunc, $total, &$i, $c) {
-                        return call_user_func($reduceFunc, $c, $value, $i++, $total);
-                    });
-                });
-            };
-
-            return array_reduce($array, $wrappedReduceFunc, $initialValue);
-        });
+        return reduce($promisesOrValues, $reduceFunc, $initialValue);
     }
 }

--- a/src/React/Promise/functions.php
+++ b/src/React/Promise/functions.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace React\Promise;
+
+if (function_exists('React\Promise\resolve')) {
+    return;
+}
+
+function resolve($promiseOrValue = null)
+{
+    return Util::promiseFor($promiseOrValue);
+}
+
+function reject($promiseOrValue = null)
+{
+    return Util::rejectedPromiseFor($promiseOrValue);
+}
+
+function all($promisesOrValues)
+{
+    return map($promisesOrValues, function ($val) {
+        return $val;
+    });
+}
+
+function any($promisesOrValues)
+{
+   return some($promisesOrValues, 1)->then(function($val) {
+        return array_shift($val);
+    });
+}
+
+function some($promisesOrValues, $howMany)
+{
+    return resolve($promisesOrValues)->then(function ($array) use ($howMany) {
+        if (!is_array($array)) {
+            $array = array();
+        }
+
+        $len       = count($array);
+        $toResolve = max(0, min($howMany, $len));
+        $values    = array();
+        $deferred  = new Deferred();
+
+        if (!$toResolve) {
+            $deferred->resolve($values);
+        } else {
+            $toReject = ($len - $toResolve) + 1;
+            $reasons  = array();
+
+            $progress = array($deferred, 'progress');
+
+            $fulfillOne = function ($val, $i) use (&$values, &$toResolve, $deferred) {
+                $values[$i] = $val;
+
+                if (0 === --$toResolve) {
+                    $deferred->resolve($values);
+
+                    return true;
+                }
+            };
+
+            $rejectOne = function ($reason, $i) use (&$reasons, &$toReject, $deferred) {
+                $reasons[$i] = $reason;
+
+                if (0 === --$toReject) {
+                    $deferred->reject($reasons);
+
+                    return true;
+                }
+            };
+
+            foreach ($array as $i => $promiseOrValue) {
+                $fulfiller = function ($val) use ($i, &$fulfillOne, &$rejectOne) {
+                    $reset = $fulfillOne($val, $i);
+
+                    if (true === $reset) {
+                        $fulfillOne = $rejectOne = function () {};
+                    }
+                };
+
+                $rejecter = function ($val) use ($i, &$fulfillOne, &$rejectOne) {
+                    $reset = $rejectOne($val, $i);
+
+                    if (true === $reset) {
+                        $fulfillOne = $rejectOne = function () {};
+                    }
+                };
+
+                resolve($promiseOrValue)->then($fulfiller, $rejecter, $progress);
+            }
+        }
+
+        return $deferred->promise();
+    });
+}
+
+function map($promisesOrValues, $mapFunc)
+{
+    return resolve($promisesOrValues)->then(function ($array) use ($mapFunc) {
+        if (!is_array($array)) {
+            $array = array();
+        }
+
+        $toResolve = count($array);
+        $results   = array();
+        $deferred  = new Deferred();
+
+        if (!$toResolve) {
+            $deferred->resolve($results);
+        } else {
+            $resolve = function ($item, $i) use ($mapFunc, &$results, &$toResolve, $deferred) {
+                resolve($item)
+                    ->then($mapFunc)
+                    ->then(
+                        function ($mapped) use (&$results, $i, &$toResolve, $deferred) {
+                            $results[$i] = $mapped;
+
+                            if (0 === --$toResolve) {
+                                $deferred->resolve($results);
+                            }
+                        },
+                        array($deferred, 'reject')
+                    );
+            };
+
+            foreach ($array as $i => $item) {
+                $resolve($item, $i);
+            }
+        }
+
+        return $deferred->promise();
+    });
+}
+
+function reduce($promisesOrValues, $reduceFunc , $initialValue = null)
+{
+    return resolve($promisesOrValues)->then(function ($array) use ($reduceFunc, $initialValue) {
+        if (!is_array($array)) {
+            $array = array();
+        }
+
+        $total = count($array);
+        $i = 0;
+
+        // Wrap the supplied $reduceFunc with one that handles promises and then
+        // delegates to the supplied.
+        $wrappedReduceFunc = function ($current, $val) use ($reduceFunc, $total, &$i) {
+            return resolve($current)->then(function ($c) use ($reduceFunc, $total, &$i, $val) {
+                return resolve($val)->then(function ($value) use ($reduceFunc, $total, &$i, $c) {
+                    return call_user_func($reduceFunc, $c, $value, $i++, $total);
+                });
+            });
+        };
+
+        return array_reduce($array, $wrappedReduceFunc, $initialValue);
+    });
+}

--- a/src/React/Promise/functions.php
+++ b/src/React/Promise/functions.php
@@ -2,10 +2,6 @@
 
 namespace React\Promise;
 
-if (function_exists('React\Promise\resolve')) {
-    return;
-}
-
 function resolve($promiseOrValue = null)
 {
     if ($promiseOrValue instanceof PromiseInterface) {

--- a/src/React/Promise/functions.php
+++ b/src/React/Promise/functions.php
@@ -8,12 +8,22 @@ if (function_exists('React\Promise\resolve')) {
 
 function resolve($promiseOrValue = null)
 {
-    return Util::promiseFor($promiseOrValue);
+    if ($promiseOrValue instanceof PromiseInterface) {
+        return $promiseOrValue;
+    }
+
+    return new FulfilledPromise($promiseOrValue);
 }
 
 function reject($promiseOrValue = null)
 {
-    return Util::rejectedPromiseFor($promiseOrValue);
+    if ($promiseOrValue instanceof PromiseInterface) {
+        return $promiseOrValue->then(function ($value) {
+            return new RejectedPromise($value);
+        });
+    }
+
+    return new RejectedPromise($promiseOrValue);
 }
 
 function all($promisesOrValues)

--- a/src/React/Promise/functions_include.php
+++ b/src/React/Promise/functions_include.php
@@ -1,0 +1,5 @@
+<?php
+
+if (!function_exists('React\Promise\resolve')) {
+    require __DIR__.'/functions.php';
+}

--- a/tests/React/Promise/PromiseTest.php
+++ b/tests/React/Promise/PromiseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace React\Promise;
+
+/**
+ * @group Promise
+ */
+class PromiseTest extends TestCase
+{
+    /** @test */
+    public function shouldThrowIfResolverIsNotACallable()
+    {
+        $this->setExpectedException('\InvalidArgumentException');
+
+        new Promise(null);
+    }
+
+    /** @test */
+    public function shouldResolve()
+    {
+        $promise = new Promise(function($resolve) {
+            $resolve(1);
+        });
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        $promise->then($mock);
+    }
+
+    /** @test */
+    public function shouldReject()
+    {
+        $promise = new Promise(function($_, $reject) {
+            $reject(1);
+        });
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        $promise->then($this->expectCallableNever(), $mock);
+    }
+
+    /** @test */
+    public function shouldProgres()
+    {
+        $promise = new Promise(function($_, $_, $progress) use (&$notify) {
+            $notify = $progress;
+        });
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableNever(), $mock);
+
+        $notify(1);
+    }
+}

--- a/tests/React/Promise/PromiseTest.php
+++ b/tests/React/Promise/PromiseTest.php
@@ -51,7 +51,7 @@ class PromiseTest extends TestCase
     /** @test */
     public function shouldReject()
     {
-        $promise = new Promise(function($_, $reject) {
+        $promise = new Promise(function($resolve, $reject) {
             $reject(1);
         });
 
@@ -67,7 +67,7 @@ class PromiseTest extends TestCase
     /** @test */
     public function shouldProgress()
     {
-        $promise = new Promise(function($_, $_, $progress) use (&$notify) {
+        $promise = new Promise(function($resolve, $reject, $progress) use (&$notify) {
             $notify = $progress;
         });
 

--- a/tests/React/Promise/PromiseTest.php
+++ b/tests/React/Promise/PromiseTest.php
@@ -65,7 +65,7 @@ class PromiseTest extends TestCase
     }
 
     /** @test */
-    public function shouldProgres()
+    public function shouldProgress()
     {
         $promise = new Promise(function($_, $_, $progress) use (&$notify) {
             $notify = $progress;

--- a/tests/React/Promise/PromiseTest.php
+++ b/tests/React/Promise/PromiseTest.php
@@ -14,6 +14,23 @@ class PromiseTest extends TestCase
 
         new Promise(null);
     }
+    /** @test */
+    public function shouldRejectIfResolverThrows()
+    {
+        $e = new \Exception();
+
+        $promise = new Promise(function() use($e) {
+            throw $e;
+        });
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($e));
+
+        $promise->then($this->expectCallableNever(), $mock);
+    }
 
     /** @test */
     public function shouldResolve()


### PR DESCRIPTION
This could become a 1.1 release which makes the API more compatible with 2.0 while preserving full backward compatibility. With this release, consuming packages can require both 1.0 (with PHP 5.3 support) and 2.0.

Changes:

* Added Promise class
* Moved methods of React\Promise\When and React\Promise\Util to functions while keeping the classes as a proxy for BC

Optional todos:

* Add ExtendedPromiseInterface
* Add CancellableInterface