### PR TITLE
Reject some() (and any()) if the input array contains not enough items

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,9 @@ will be the resolution value of the triggering item.
 The returned promise will only reject if *all* items in `$promisesOrValues` are
 rejected. The rejection value will be an array of all rejection reasons.
 
+The returned promise will also reject with a `React\Promise\Exception\RangeException`
+if `$promisesOrValues` contains 0 items.
+
 #### some()
 
 ```php

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ will be the resolution value of the triggering item.
 The returned promise will only reject if *all* items in `$promisesOrValues` are
 rejected. The rejection value will be an array of all rejection reasons.
 
-The returned promise will also reject with a `React\Promise\Exception\RangeException`
+The returned promise will also reject with a `React\Promise\Exception\LengthException`
 if `$promisesOrValues` contains 0 items.
 
 #### some()
@@ -534,7 +534,7 @@ to resolve (that is, when `(count($promisesOrValues) - $howMany) + 1` items
 reject). The rejection value will be an array of
 `(count($promisesOrValues) - $howMany) + 1` rejection reasons.
 
-The returned promise will also reject with a `React\Promise\Exception\RangeException`
+The returned promise will also reject with a `React\Promise\Exception\LengthException`
 if `$promisesOrValues` contains less items than `$howMany`.
 
 #### map()

--- a/README.md
+++ b/README.md
@@ -531,6 +531,9 @@ to resolve (that is, when `(count($promisesOrValues) - $howMany) + 1` items
 reject). The rejection value will be an array of
 `(count($promisesOrValues) - $howMany) + 1` rejection reasons.
 
+The returned promise will also reject with a `React\Promise\Exception\RangeException`
+if `$promisesOrValues` contains less items than `$howMany`.
+
 #### map()
 
 ```php

--- a/src/Exception/LengthException.php
+++ b/src/Exception/LengthException.php
@@ -2,6 +2,6 @@
 
 namespace React\Promise\Exception;
 
-class RangeException extends \RangeException
+class LengthException extends \LengthException
 {
 }

--- a/src/Exception/RangeException.php
+++ b/src/Exception/RangeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace React\Promise\Exception;
+
+class RangeException extends \RangeException
+{
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -71,7 +71,7 @@ function some($promisesOrValues, $howMany)
             $len = count($array);
 
             if ($len < $howMany) {
-                throw new \RangeException(
+                throw new Exception\RangeException(
                     sprintf(
                         'Input array must contain at least %d item%s but contains only %s item%s.',
                         $howMany,

--- a/src/functions.php
+++ b/src/functions.php
@@ -103,7 +103,7 @@ function some($promisesOrValues, $howMany)
                     );
                 }
 
-                $toResolve = min($howMany, $len);
+                $toResolve = $howMany;
                 $toReject  = ($len - $toResolve) + 1;
                 $values    = [];
                 $reasons   = [];

--- a/src/functions.php
+++ b/src/functions.php
@@ -71,7 +71,7 @@ function some($promisesOrValues, $howMany)
             $len = count($array);
 
             if ($len < $howMany) {
-                throw new Exception\RangeException(
+                throw new Exception\LengthException(
                     sprintf(
                         'Input array must contain at least %d item%s but contains only %s item%s.',
                         $howMany,

--- a/src/functions.php
+++ b/src/functions.php
@@ -64,12 +64,25 @@ function some($promisesOrValues, $howMany)
 {
     return resolve($promisesOrValues)
         ->then(function ($array) use ($howMany) {
-            if (!is_array($array) || !$array || $howMany < 1) {
-                return resolve([]);
+            if (!is_array($array) || $howMany < 1) {
+                return [];
             }
 
-            return new Promise(function ($resolve, $reject, $notify) use ($array, $howMany) {
-                $len       = count($array);
+            $len = count($array);
+
+            if ($len < $howMany) {
+                throw new \RangeException(
+                    sprintf(
+                        'Input array must contain at least %d item%s but contains only %s item%s.',
+                        $howMany,
+                        1 === $howMany ? '' : 's',
+                        $len,
+                        1 === $len ? '' : 's'
+                    )
+                );
+            }
+
+            return new Promise(function ($resolve, $reject, $notify) use ($array, $howMany, $len) {
                 $toResolve = min($howMany, $len);
                 $toReject  = ($len - $toResolve) + 1;
                 $values    = [];

--- a/tests/FunctionAnyTest.php
+++ b/tests/FunctionAnyTest.php
@@ -5,7 +5,25 @@ namespace React\Promise;
 class FunctionAnyTest extends TestCase
 {
     /** @test */
-    public function shouldResolveToNullWithEmptyInputArray()
+    public function shouldRejectWithRangeExceptionWithEmptyInputArray()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->callback(function($exception){
+                    return $exception instanceof \RangeException &&
+                           'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
+                })
+            );
+
+        any([])
+            ->then($this->expectCallableNever(), $mock);
+    }
+
+    /** @test */
+    public function shouldResolveToNullWithNonArrayInput()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -13,7 +31,7 @@ class FunctionAnyTest extends TestCase
             ->method('__invoke')
             ->with($this->identicalTo(null));
 
-        any([])
+        any(null)
             ->then($mock);
     }
 

--- a/tests/FunctionAnyTest.php
+++ b/tests/FunctionAnyTest.php
@@ -2,6 +2,8 @@
 
 namespace React\Promise;
 
+use React\Promise\Exception\RangeException;
+
 class FunctionAnyTest extends TestCase
 {
     /** @test */
@@ -13,7 +15,7 @@ class FunctionAnyTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->callback(function($exception){
-                    return $exception instanceof \RangeException &&
+                    return $exception instanceof RangeException &&
                            'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
                 })
             );

--- a/tests/FunctionAnyTest.php
+++ b/tests/FunctionAnyTest.php
@@ -2,12 +2,12 @@
 
 namespace React\Promise;
 
-use React\Promise\Exception\RangeException;
+use React\Promise\Exception\LengthException;
 
 class FunctionAnyTest extends TestCase
 {
     /** @test */
-    public function shouldRejectWithRangeExceptionWithEmptyInputArray()
+    public function shouldRejectWithLengthExceptionWithEmptyInputArray()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -15,7 +15,7 @@ class FunctionAnyTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->callback(function($exception){
-                    return $exception instanceof RangeException &&
+                    return $exception instanceof LengthException &&
                            'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
                 })
             );

--- a/tests/FunctionSomeTest.php
+++ b/tests/FunctionSomeTest.php
@@ -5,7 +5,47 @@ namespace React\Promise;
 class FunctionSomeTest extends TestCase
 {
     /** @test */
-    public function shouldResolveEmptyInput()
+    public function shouldRejectWithRangeExceptionWithEmptyInputArray()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->callback(function($exception){
+                    return $exception instanceof \RangeException &&
+                    'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
+                })
+            );
+
+        some(
+            [],
+            1
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    /** @test */
+    public function shouldRejectWithRangeExceptionWithInputArrayContainingNotEnoughItems()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->callback(function($exception){
+                    return $exception instanceof \RangeException &&
+                    'Input array must contain at least 4 items but contains only 3 items.' === $exception->getMessage();
+                })
+            );
+
+        some(
+            [1, 2, 3],
+            4
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    /** @test */
+    public function shouldResolveToEmptyArrayWithNonArrayInput()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -14,7 +54,7 @@ class FunctionSomeTest extends TestCase
             ->with($this->identicalTo([]));
 
         some(
-            [],
+            null,
             1
         )->then($mock);
     }

--- a/tests/FunctionSomeTest.php
+++ b/tests/FunctionSomeTest.php
@@ -2,12 +2,12 @@
 
 namespace React\Promise;
 
-use React\Promise\Exception\RangeException;
+use React\Promise\Exception\LengthException;
 
 class FunctionSomeTest extends TestCase
 {
     /** @test */
-    public function shouldRejectWithRangeExceptionWithEmptyInputArray()
+    public function shouldRejectWithLengthExceptionWithEmptyInputArray()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -15,7 +15,7 @@ class FunctionSomeTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->callback(function($exception){
-                    return $exception instanceof RangeException &&
+                    return $exception instanceof LengthException &&
                            'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
                 })
             );
@@ -27,7 +27,7 @@ class FunctionSomeTest extends TestCase
     }
 
     /** @test */
-    public function shouldRejectWithRangeExceptionWithInputArrayContainingNotEnoughItems()
+    public function shouldRejectWithLengthExceptionWithInputArrayContainingNotEnoughItems()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -35,7 +35,7 @@ class FunctionSomeTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->callback(function($exception){
-                    return $exception instanceof RangeException &&
+                    return $exception instanceof LengthException &&
                            'Input array must contain at least 4 items but contains only 3 items.' === $exception->getMessage();
                 })
             );

--- a/tests/FunctionSomeTest.php
+++ b/tests/FunctionSomeTest.php
@@ -2,6 +2,8 @@
 
 namespace React\Promise;
 
+use React\Promise\Exception\RangeException;
+
 class FunctionSomeTest extends TestCase
 {
     /** @test */
@@ -13,8 +15,8 @@ class FunctionSomeTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->callback(function($exception){
-                    return $exception instanceof \RangeException &&
-                    'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
+                    return $exception instanceof RangeException &&
+                           'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
                 })
             );
 
@@ -33,8 +35,8 @@ class FunctionSomeTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->callback(function($exception){
-                    return $exception instanceof \RangeException &&
-                    'Input array must contain at least 4 items but contains only 3 items.' === $exception->getMessage();
+                    return $exception instanceof RangeException &&
+                           'Input array must contain at least 4 items but contains only 3 items.' === $exception->getMessage();
                 })
             );
 


### PR DESCRIPTION
This fixes a bug where some() never resolves if the input array contains not enough items.

```php
some([1, 2, 3], 4)->then(function() {
    // Never called
});
```
