### PR TITLE
Fix two PHP syntax errors

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -112,7 +112,7 @@ function map($promisesOrValues, callable $mapFunc)
     return resolve($promisesOrValues)
         ->then(function ($array) use ($mapFunc) {
             if (!is_array($array) || !$array) {
-                return resolve([]);
+                return resolve();
             }
 
             return new Promise(function ($resolve, $reject, $notify) use ($array, $mapFunc) {


### PR DESCRIPTION
There were two syntax errors in `src/functions.php`.  This pull request fixes them both.

Applies to https://github.com/reactphp/promise/issues/38.