### PR TITLE
Cancellation handler must only be called once, ignore double cancellation

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -91,7 +91,10 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
             return;
         }
 
-        $this->call($this->canceller);
+        $canceller = $this->canceller;
+        $this->canceller = null;
+
+        $this->call($canceller);
     }
 
     private function resolver(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null)

--- a/tests/PromiseTest/CancelTestTrait.php
+++ b/tests/PromiseTest/CancelTestTrait.php
@@ -190,6 +190,31 @@ trait CancelTestTrait
     }
 
     /** @test */
+    public function cancelShouldNotTriggerCancellerWhenCancellingOneChildrenMultipleTimes()
+    {
+        $adapter = $this->getPromiseTestAdapter($this->expectCallableNever());
+
+        $child1 = $adapter->promise()
+            ->then()
+            ->then();
+
+        $child2 = $adapter->promise()
+            ->then();
+
+        $child1->cancel();
+        $child1->cancel();
+    }
+
+    /** @test */
+    public function cancelShouldTriggerCancellerOnlyOnceWhenCancellingMultipleTimes()
+    {
+        $adapter = $this->getPromiseTestAdapter($this->expectCallableOnce());
+
+        $adapter->promise()->cancel();
+        $adapter->promise()->cancel();
+    }
+
+    /** @test */
     public function cancelShouldAlwaysTriggerCancellerWhenCalledOnRootPromise()
     {
         $adapter = $this->getPromiseTestAdapter($this->expectCallableOnce());


### PR DESCRIPTION
As a first step, this ticket aims to document the current behavior. Following, we should fix the first test case and probably also reconsider the second one.

Opening this ticket as an RFC and for the reference.