### PR TITLE
Backport promise cancellation support to v1 Promise API

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ a promise has no effect.
 
 * [FulfilledPromise](#fulfilledpromise)
 * [RejectedPromise](#rejectedpromise)
+* [LazyPromise](#lazypromise)
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Table of Contents
      * [When::reject()](#whenreject)
      * [When::lazy()](#whenlazy)
    * [Promisor](#promisor)
+   * [CancellablePromiseInterface](#cancellablepromiseinterface)
+     * [CancellablePromiseInterface::cancel()](#cancellablepromiseinterfacecancel)
 4. [Examples](#examples)
    * [How to use Deferred](#how-to-use-deferred)
    * [How Promise forwarding works](#how-promise-forwarding-works)
@@ -483,6 +485,24 @@ $promise->then(function ($value) {
 The `React\Promise\PromisorInterface` provides a common interface for objects
 that provide a promise. `React\Promise\Deferred` implements it, but since it
 is part of the public API anyone can implement it.
+
+### CancellablePromiseInterface
+
+A cancellable promise provides a mechanism for consumers to notify the creator
+of the promise that they are not longer interested in the result of an
+operation.
+
+#### CancellablePromiseInterface::cancel()
+
+``` php
+$promise->cancel();
+```
+
+The `cancel()` method notifies the creator of the promise that there is no
+further interest in the results of the operation.
+
+Once a promise is settled (either resolved or rejected), calling `cancel()` on
+a promise has no effect.
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ $deferred->reject(mixed $reason = null);
 $deferred->progress(mixed $update = null);
 ```
 
+The constructor of the `Deferred` accepts an optional `$canceller` argument.
+See [Promise](#promise-1) for more information.
+
+
+``` php
+$deferred = new React\Promise\Deferred(function ($resolve, $reject, $progress) {
+    throw new \Exception('Promise cancelled');
+});
+
+$deferred->cancel();
+```
+
 ### Promise
 
 The Promise represents the eventual outcome, which is either fulfillment
@@ -135,7 +147,13 @@ $resolver = function (callable $resolve, callable $reject, callable $notify) {
     // or $notify($progressNotification);
 };
 
-$promise = new React\Promise\Promise($resolver);
+$canceller = function (callable $resolve, callable $reject, callable $progress) {
+    // Cancel/abort any running operations like network connections, streams etc.
+
+    $reject(new \Exception('Promise cancelled'));
+};
+
+$promise = new React\Promise\Promise($resolver, $canceller);
 ```
 
 The promise constructor receives a resolver function which will be called
@@ -151,6 +169,9 @@ immediately with 3 arguments:
 
 If the resolver throws an exception, the promise will be rejected with that
 thrown exception as the rejection reason.
+
+The resolver function will be called immediately, the canceller function only
+once all consumers called the `cancel()` method of the promise.
 
 A Promise has a single method `then()` which registers new fulfilled, error and
 progress handlers with this Promise (all parameters are optional):
@@ -506,6 +527,8 @@ a promise has no effect.
 
 #### Implementations
 
+* [Deferred](#deferred-1)
+* [Promise](#promise-1)
 * [FulfilledPromise](#fulfilledpromise)
 * [RejectedPromise](#rejectedpromise)
 * [LazyPromise](#lazypromise)

--- a/README.md
+++ b/README.md
@@ -504,6 +504,11 @@ further interest in the results of the operation.
 Once a promise is settled (either resolved or rejected), calling `cancel()` on
 a promise has no effect.
 
+#### Implementations
+
+* [FulfilledPromise](#fulfilledpromise)
+* [RejectedPromise](#rejectedpromise)
+
 Examples
 --------
 

--- a/src/React/Promise/CancellablePromiseInterface.php
+++ b/src/React/Promise/CancellablePromiseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace React\Promise;
+
+interface CancellablePromiseInterface extends PromiseInterface
+{
+    /**
+     * @return void
+     */
+    public function cancel();
+}

--- a/src/React/Promise/Deferred.php
+++ b/src/React/Promise/Deferred.php
@@ -128,11 +128,14 @@ class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface
             return;
         }
 
+        $canceller = $this->canceller;
+        $this->canceller = null;
+
         try {
             $that = $this;
 
             call_user_func(
-                $this->canceller,
+                $canceller,
                 function ($value = null) use ($that) {
                     $that->resolve($value);
                 },

--- a/src/React/Promise/Deferred.php
+++ b/src/React/Promise/Deferred.php
@@ -16,6 +16,15 @@ class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface
 
     public function __construct($canceller = null)
     {
+        if ($canceller !== null && !is_callable($canceller)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'The canceller argument must be null or of type callable, %s given.',
+                    gettype($canceller)
+                )
+            );
+        }
+
         $this->canceller = $canceller;
     }
 

--- a/src/React/Promise/Deferred.php
+++ b/src/React/Promise/Deferred.php
@@ -2,13 +2,22 @@
 
 namespace React\Promise;
 
-class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface
+class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface, CancellablePromiseInterface
 {
     private $completed;
     private $promise;
     private $resolver;
     private $handlers = array();
     private $progressHandlers = array();
+    private $canceller;
+
+    private $requiredCancelRequests = 0;
+    private $cancelRequests = 0;
+
+    public function __construct($canceller = null)
+    {
+        $this->canceller = $canceller;
+    }
 
     public function then($fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
     {
@@ -16,7 +25,24 @@ class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface
             return $this->completed->then($fulfilledHandler, $errorHandler, $progressHandler);
         }
 
-        $deferred = new static();
+        $canceller = null;
+        if ($this->canceller !== null) {
+            $this->requiredCancelRequests++;
+
+            $that = $this;
+            $current =& $this->cancelRequests;
+            $required =& $this->requiredCancelRequests;
+
+            $canceller = function () use ($that, &$current, &$required) {
+                if (++$current < $required) {
+                    return;
+                }
+
+                $that->cancel();
+            };
+        }
+
+        $deferred = new static($canceller);
 
         if (is_callable($progressHandler)) {
             $progHandler = function ($update) use ($deferred, $progressHandler) {
@@ -94,6 +120,32 @@ class Deferred implements PromiseInterface, ResolverInterface, PromisorInterface
         }
 
         return $this->resolver;
+    }
+
+    public function cancel()
+    {
+        if (null === $this->canceller || null !== $this->completed) {
+            return;
+        }
+
+        try {
+            $that = $this;
+
+            call_user_func(
+                $this->canceller,
+                function ($value = null) use ($that) {
+                    $that->resolve($value);
+                },
+                function ($reason = null) use ($that) {
+                    $that->reject($reason);
+                },
+                function ($update = null) use ($that) {
+                    $that->progress($update);
+                }
+            );
+        } catch (\Exception $e) {
+            $this->reject($e);
+        }
     }
 
     protected function processQueue($queue, $value)

--- a/src/React/Promise/DeferredPromise.php
+++ b/src/React/Promise/DeferredPromise.php
@@ -15,4 +15,9 @@ class DeferredPromise implements PromiseInterface
     {
         return $this->deferred->then($fulfilledHandler, $errorHandler, $progressHandler);
     }
+
+    public function cancel()
+    {
+        $this->deferred->cancel();
+    }
 }

--- a/src/React/Promise/FulfilledPromise.php
+++ b/src/React/Promise/FulfilledPromise.php
@@ -2,7 +2,7 @@
 
 namespace React\Promise;
 
-class FulfilledPromise implements PromiseInterface
+class FulfilledPromise implements PromiseInterface, CancellablePromiseInterface
 {
     private $result;
 
@@ -26,5 +26,9 @@ class FulfilledPromise implements PromiseInterface
         } catch (\Exception $exception) {
             return new RejectedPromise($exception);
         }
+    }
+
+    public function cancel()
+    {
     }
 }

--- a/src/React/Promise/LazyPromise.php
+++ b/src/React/Promise/LazyPromise.php
@@ -2,7 +2,7 @@
 
 namespace React\Promise;
 
-class LazyPromise implements PromiseInterface
+class LazyPromise implements PromiseInterface, CancellablePromiseInterface
 {
     private $factory;
     private $promise;
@@ -14,6 +14,19 @@ class LazyPromise implements PromiseInterface
 
     public function then($fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
     {
+        return $this->promise()->then($fulfilledHandler, $errorHandler, $progressHandler);
+    }
+
+    public function cancel()
+    {
+        $promise = $this->promise();
+        if ($promise instanceof CancellablePromiseInterface) {
+            $promise->cancel();
+        }
+    }
+
+    private function promise()
+    {
         if (null === $this->promise) {
             try {
                 $this->promise = resolve(call_user_func($this->factory));
@@ -21,7 +34,6 @@ class LazyPromise implements PromiseInterface
                 $this->promise = new RejectedPromise($exception);
             }
         }
-
-        return $this->promise->then($fulfilledHandler, $errorHandler, $progressHandler);
+        return $this->promise;
     }
 }

--- a/src/React/Promise/Promise.php
+++ b/src/React/Promise/Promise.php
@@ -2,11 +2,11 @@
 
 namespace React\Promise;
 
-class Promise implements PromiseInterface
+class Promise implements PromiseInterface, CancellablePromiseInterface
 {
     private $deferred;
 
-    public function __construct($resolver)
+    public function __construct($resolver, $canceller = null)
     {
         if (!is_callable($resolver)) {
             throw new \InvalidArgumentException(
@@ -17,13 +17,18 @@ class Promise implements PromiseInterface
             );
         }
 
-        $this->deferred = new Deferred();
+        $this->deferred = new Deferred($canceller);
         $this->call($resolver);
     }
 
     public function then($fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
     {
         return $this->deferred->then($fulfilledHandler, $errorHandler, $progressHandler);
+    }
+
+    public function cancel()
+    {
+        $this->deferred->cancel();
     }
 
     private function call($callback)

--- a/src/React/Promise/RejectedPromise.php
+++ b/src/React/Promise/RejectedPromise.php
@@ -2,7 +2,7 @@
 
 namespace React\Promise;
 
-class RejectedPromise implements PromiseInterface
+class RejectedPromise implements PromiseInterface, CancellablePromiseInterface
 {
     private $reason;
 
@@ -26,5 +26,9 @@ class RejectedPromise implements PromiseInterface
         } catch (\Exception $exception) {
             return new RejectedPromise($exception);
         }
+    }
+
+    public function cancel()
+    {
     }
 }

--- a/tests/React/Promise/DeferredPromiseTest.php
+++ b/tests/React/Promise/DeferredPromiseTest.php
@@ -20,4 +20,16 @@ class DeferredPromiseTest extends TestCase
         $p = new DeferredPromise($mock);
         $p->then(1, 2, 3);
     }
+
+    /** @test */
+    public function shouldForwardCancelToDeferred()
+    {
+        $mock = $this->getMock('React\\Promise\\Deferred');
+        $mock
+            ->expects($this->once())
+            ->method('cancel');
+
+        $p = new DeferredPromise($mock);
+        $p->cancel();
+    }
 }

--- a/tests/React/Promise/DeferredTest.php
+++ b/tests/React/Promise/DeferredTest.php
@@ -115,6 +115,14 @@ class DeferredTest extends TestCase
     }
 
     /** @test */
+    public function shouldInvokeCancellationHandlerOnlyOnceWhenCallingCancelMultipleTimes()
+    {
+        $d = new Deferred($this->expectCallableOnce());
+        $d->cancel();
+        $d->cancel();
+    }
+
+    /** @test */
     public function shouldResolveWhenCancellationHandlerResolves()
     {
         $d = new Deferred(function ($resolve) {

--- a/tests/React/Promise/DeferredTest.php
+++ b/tests/React/Promise/DeferredTest.php
@@ -84,4 +84,113 @@ class DeferredTest extends TestCase
 
         $this->assertNull($d->progress());
     }
+
+    /** @test */
+    public function shouldIgnoreCancellationWithNoCancellationHandlerAndStayPending()
+    {
+        $d = new Deferred();
+        $d->cancel();
+
+        $d->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    /** @test */
+    public function shouldIgnoreCancellationWhenAlreadySettled()
+    {
+        $d = new Deferred($this->expectCallableNever());
+        $d->resolve();
+
+        $d->cancel();
+
+        $d->then($this->expectCallableOnce(), $this->expectCallableNever());
+    }
+
+    /** @test */
+    public function shouldInvokeCancellationHandlerAndStayPendingWhenCallingCancel()
+    {
+        $d = new Deferred($this->expectCallableOnce());
+        $d->cancel();
+
+        $d->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    /** @test */
+    public function shouldResolveWhenCancellationHandlerResolves()
+    {
+        $d = new Deferred(function ($resolve) {
+            $resolve();
+        });
+
+        $d->cancel();
+
+        $d->then($this->expectCallableOnce(), $this->expectCallableNever());
+    }
+
+    /** @test */
+    public function shouldRejectWhenCancellationHandlerRejects()
+    {
+        $d = new Deferred(function ($_, $reject) {
+            $reject();
+        });
+
+        $d->cancel();
+
+        $d->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    /** @test */
+    public function shouldRejectWhenCancellationHandlerThrows()
+    {
+        $d = new Deferred(function () {
+            throw new \Exception();
+        });
+
+        $d->cancel();
+
+        $d->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    /** @test */
+    public function shouldProgressWhenCancellationHandlerEmitsProgress()
+    {
+        $d = new Deferred(function ($_, $__, $progress) {
+            $progress();
+        });
+
+        $d->then(null, null, $this->expectCallableOnce());
+
+        $d->cancel();
+    }
+
+    /** @test */
+    public function shouldInvokeCancellationHandleWhenCancellingDerived()
+    {
+        $d = new Deferred($this->expectCallableOnce());
+
+        $p = $d->then();
+        $p->cancel();
+    }
+
+    /** @test */
+    public function shouldNotInvokeCancellationHandleWhenCancellingNotAllDerived()
+    {
+        $d = new Deferred($this->expectCallableNever());
+
+        $p1 = $d->then();
+        $p2 = $d->then();
+
+        $p1->cancel();
+    }
+
+    /** @test */
+    public function shouldInvokeCancellationHandleWhenCancellingAllDerived()
+    {
+        $d = new Deferred($this->expectCallableOnce());
+
+        $p1 = $d->then();
+        $p2 = $d->then();
+
+        $p1->cancel();
+        $p2->cancel();
+    }
 }

--- a/tests/React/Promise/DeferredTest.php
+++ b/tests/React/Promise/DeferredTest.php
@@ -201,4 +201,13 @@ class DeferredTest extends TestCase
         $p1->cancel();
         $p2->cancel();
     }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function shouldThrowIfCancellerIsNotACallable()
+    {
+        new Deferred(false);
+    }
 }

--- a/tests/React/Promise/FulfilledPromiseTest.php
+++ b/tests/React/Promise/FulfilledPromiseTest.php
@@ -140,4 +140,12 @@ class FulfilledPromiseTest extends TestCase
                 $mock2
             );
     }
+
+    /** @test */
+    public function shouldNotBeAffectedByCancellation()
+    {
+        $p = new FulfilledPromise(1);
+        $p->cancel();
+        $p->then($this->expectCallableOnce());
+    }
 }

--- a/tests/React/Promise/LazyPromiseTest.php
+++ b/tests/React/Promise/LazyPromiseTest.php
@@ -63,12 +63,12 @@ class LazyPromiseTest extends TestCase
         $p = new LazyPromise($factory);
         $this->assertInstanceOf('React\\Promise\\PromiseInterface', $p->then());
     }
-    
+
     /** @test */
     public function shouldReturnRejectedPromiseIfFactoryThrowsException()
     {
         $exception = new \Exception();
-        
+
         $factory = $this->createCallableMock();
         $factory
             ->expects($this->once())
@@ -84,5 +84,35 @@ class LazyPromiseTest extends TestCase
         $p = new LazyPromise($factory);
 
         $p->then($this->expectCallableNever(), $errorHandler);
+    }
+
+    /** @test */
+    public function shouldInvokeCancellationHandlerAndStayPendingWhenCallingCancel()
+    {
+        $once = $this->expectCallableOnce();
+
+        $factory = function () use ($once){
+            return new Deferred($once);
+        };
+
+        $p = new LazyPromise($factory);
+        $p->cancel();
+
+        $p->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    /** @test */
+    public function shouldNotInvokeCancellationHandlerIfPromiseIsNotCancellable()
+    {
+        $mock = $this->getMock('React\\Promise\\PromiseInterface');
+
+        $factory = function () use ($mock){
+            return $mock;
+        };
+
+        $p = new LazyPromise($factory);
+        $p->cancel();
+
+        $p->then($this->expectCallableNever(), $this->expectCallableNever());
     }
 }

--- a/tests/React/Promise/PromiseTest.php
+++ b/tests/React/Promise/PromiseTest.php
@@ -81,4 +81,13 @@ class PromiseTest extends TestCase
 
         $notify(1);
     }
+
+    /** @test */
+    public function shouldInvokeCancellationHandlerAndStayPendingWhenCallingCancel()
+    {
+        $promise = new Promise(function() { }, $this->expectCallableOnce());
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
 }

--- a/tests/React/Promise/PromiseTest.php
+++ b/tests/React/Promise/PromiseTest.php
@@ -90,4 +90,13 @@ class PromiseTest extends TestCase
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
     }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function shouldThrowIfCancellerIsNotACallable()
+    {
+        new Promise(function () { }, false);
+    }
 }

--- a/tests/React/Promise/RejectedPromiseTest.php
+++ b/tests/React/Promise/RejectedPromiseTest.php
@@ -145,4 +145,12 @@ class RejectedPromiseTest extends TestCase
                 $mock
             );
     }
+
+    /** @test */
+    public function shouldNotBeAffectedByCancellation()
+    {
+        $p = new RejectedPromise(1);
+        $p->cancel();
+        $p->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
 }


### PR DESCRIPTION
This is an independent backport of promise cancellation support for the legacy v1 Promise API. It implements the same API as originally implemented in #20, but does not share a single line of code. Original concept courtesy of @jsor.

The main purpose here is backwards compatibility for promise consumers, which can rely on the cancellation API to be available for newer v2 as well as legacy v1 promises.