### PR TITLE
Handle \Throwable in the same way as \Exception

### DIFF
--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -23,6 +23,8 @@ class FulfilledPromise implements ExtendedPromiseInterface, CancellablePromiseIn
 
         try {
             return resolve($onFulfilled($this->value));
+        } catch (\Throwable $exception) {
+            return new RejectedPromise($exception);
         } catch (\Exception $exception) {
             return new RejectedPromise($exception);
         }

--- a/src/LazyPromise.php
+++ b/src/LazyPromise.php
@@ -47,6 +47,8 @@ class LazyPromise implements ExtendedPromiseInterface, CancellablePromiseInterfa
         if (null === $this->promise) {
             try {
                 $this->promise = resolve(call_user_func($this->factory));
+            } catch (\Throwable $exception) {
+                $this->promise = new RejectedPromise($exception);
             } catch (\Exception $exception) {
                 $this->promise = new RejectedPromise($exception);
             }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -104,6 +104,8 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
                 $progressHandler = function ($update) use ($notify, $onProgress) {
                     try {
                         $notify($onProgress($update));
+                    } catch (\Throwable $e) {
+                        $notify($e);
                     } catch (\Exception $e) {
                         $notify($e);
                     }
@@ -186,6 +188,8 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
                     $this->notify($update);
                 }
             );
+        } catch (\Throwable $e) {
+            $this->reject($e);
         } catch (\Exception $e) {
             $this->reject($e);
         }

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -23,6 +23,8 @@ class RejectedPromise implements ExtendedPromiseInterface, CancellablePromiseInt
 
         try {
             return resolve($onRejected($this->reason));
+        } catch (\Throwable $exception) {
+            return new RejectedPromise($exception);
         } catch (\Exception $exception) {
             return new RejectedPromise($exception);
         }

--- a/src/UnhandledRejectionException.php
+++ b/src/UnhandledRejectionException.php
@@ -8,7 +8,7 @@ class UnhandledRejectionException extends \RuntimeException
 
     public static function resolve($reason)
     {
-        if ($reason instanceof \Exception) {
+        if ($reason instanceof \Exception || $reason instanceof \Throwable) {
             return $reason;
         }
 


### PR DESCRIPTION
This is a backwards-compatible change which enables react/promise to handle PHP7's `\Throwable` in the same way it handles PHP5's `\Exception`.

I'd really love to get this merged asap as it's a trivial change which is backwards compatible and `\Errors` are currently causing instability in a production app which we've got running on PHP7.
