### PR TITLE
De-reference downstream promises when cancelled

### DIFF
--- a/tests/CancellationMemLeakTest.php
+++ b/tests/CancellationMemLeakTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace React\Promise;
+
+class CancellationMemLeakTest extends TestCase
+{
+    public function testCancelCleansUp()
+    {
+        $mainDeferred = new Deferred;
+
+        $memoryUsage = memory_get_usage();
+
+        for ($i = 0; $i < 100000; $i++) {
+            $innerDeferred = new Deferred;
+            race([$mainDeferred->promise()->then(), $innerDeferred->promise()]);
+            $innerDeferred->resolve();
+        }
+
+        $this->assertLessThan(2 * $memoryUsage, memory_get_usage());
+    }
+}


### PR DESCRIPTION
See the added test to understand what this optimisation is about. Essentially, I am proposing that when a downstream promise is cancelled, its handlers are removed from the upstream promise.

Prior to the changes to `Promise`, test which is included in this PR uses around 500MB of memory and takes around 30s to run on my machine using PHP5.5. With the patch, memory usage stays at around 13MB and the test takes approximately 4.5s to complete.