### PR TITLE
Revert automatic cancellation of pending collection promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG for 2.x
 =================
 
-* 2.4.2 (xxxx-xx-xx)
+* 2.5.0 (xxxx-xx-xx)
 
     * Revert automatic cancellation of pending collection promises once the
       output promise resolves. This was introduced in 42d86b7 (PR #36, released

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG for 2.x
 * 2.4.2 (xxxx-xx-xx)
 
     * Revert automatic cancellation of pending collection promises once the
-      output promise resolves. This was introduced in 42d86b7 and was both
-      unintended and backward incompatible.
+      output promise resolves. This was introduced in 42d86b7 (PR #36, released
+      in [v2.3.0](https://github.com/reactphp/promise/releases/tag/v2.3.0)) and
+      was both unintended and backward incompatible.
 
 * 2.4.1 (2016-05-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG for 2.x
 =================
 
+* 2.4.2 (xxxx-xx-xx)
+
+    * Revert automatic cancellation of pending collection promises once the
+      output promise resolves. This was introduced in 42d86b7 and was both
+      unintended and backward incompatible.
+
 * 2.4.1 (2016-05-03)
 
     * Fix `some()` not cancelling pending promises when too much input promises

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ CHANGELOG for 2.x
       in [v2.3.0](https://github.com/reactphp/promise/releases/tag/v2.3.0)) and
       was both unintended and backward incompatible.
 
+      If you need automatic cancellation, you can use something like:
+
+      ```php
+      function allAndCancel(array $promises)
+      {
+           return \React\Promise\all($promises)
+               ->always(function() use ($promises) {
+                   foreach ($promises as $promise) {
+                       if ($promise instanceof \React\Promise\CancellablePromiseInterface) {
+                           $promise->cancel();
+                       }
+                   }
+              });
+      }
+      ```
+
 * 2.4.1 (2016-05-03)
 
     * Fix `some()` not cancelling pending promises when too much input promises

--- a/src/functions.php
+++ b/src/functions.php
@@ -54,21 +54,11 @@ function race($promisesOrValues)
                     return;
                 }
 
-                $fulfiller = function ($value) use ($cancellationQueue, $resolve) {
-                    $cancellationQueue();
-                    $resolve($value);
-                };
-
-                $rejecter = function ($reason) use ($cancellationQueue, $reject) {
-                    $cancellationQueue();
-                    $reject($reason);
-                };
-
                 foreach ($array as $promiseOrValue) {
                     $cancellationQueue->enqueue($promiseOrValue);
 
                     resolve($promiseOrValue)
-                        ->done($fulfiller, $rejecter, $notify);
+                        ->done($resolve, $reject, $notify);
                 }
             }, $reject, $notify);
     }, $cancellationQueue);
@@ -115,7 +105,7 @@ function some($promisesOrValues, $howMany)
                 $reasons   = [];
 
                 foreach ($array as $i => $promiseOrValue) {
-                    $fulfiller = function ($val) use ($i, &$values, &$toResolve, $toReject, $resolve, $cancellationQueue) {
+                    $fulfiller = function ($val) use ($i, &$values, &$toResolve, $toReject, $resolve) {
                         if ($toResolve < 1 || $toReject < 1) {
                             return;
                         }
@@ -123,12 +113,11 @@ function some($promisesOrValues, $howMany)
                         $values[$i] = $val;
 
                         if (0 === --$toResolve) {
-                            $cancellationQueue();
                             $resolve($values);
                         }
                     };
 
-                    $rejecter = function ($reason) use ($i, &$reasons, &$toReject, $toResolve, $reject, $cancellationQueue) {
+                    $rejecter = function ($reason) use ($i, &$reasons, &$toReject, $toResolve, $reject) {
                         if ($toResolve < 1 || $toReject < 1) {
                             return;
                         }
@@ -136,7 +125,6 @@ function some($promisesOrValues, $howMany)
                         $reasons[$i] = $reason;
 
                         if (0 === --$toReject) {
-                            $cancellationQueue();
                             $reject($reasons);
                         }
                     };

--- a/tests/FunctionAnyTest.php
+++ b/tests/FunctionAnyTest.php
@@ -175,7 +175,7 @@ class FunctionAnyTest extends TestCase
     }
 
     /** @test */
-    public function shouldCancelOtherPendingInputArrayPromisesIfOnePromiseFulfills()
+    public function shouldNotCancelOtherPendingInputArrayPromisesIfOnePromiseFulfills()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -188,7 +188,7 @@ class FunctionAnyTest extends TestCase
 
         $mock2 = $this->getMock('React\Promise\CancellablePromiseInterface');
         $mock2
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('cancel');
 
         some([$deferred->promise(), $mock2], 1)->cancel();

--- a/tests/FunctionRaceTest.php
+++ b/tests/FunctionRaceTest.php
@@ -162,7 +162,7 @@ class FunctionRaceTest extends TestCase
     }
 
     /** @test */
-    public function shouldCancelOtherPendingInputArrayPromisesIfOnePromiseFulfills()
+    public function shouldNotCancelOtherPendingInputArrayPromisesIfOnePromiseFulfills()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -174,14 +174,14 @@ class FunctionRaceTest extends TestCase
 
         $mock2 = $this->getMock('React\Promise\CancellablePromiseInterface');
         $mock2
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('cancel');
 
         race([$deferred->promise(), $mock2])->cancel();
     }
 
     /** @test */
-    public function shouldCancelOtherPendingInputArrayPromisesIfOnePromiseRejects()
+    public function shouldNotCancelOtherPendingInputArrayPromisesIfOnePromiseRejects()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -193,7 +193,7 @@ class FunctionRaceTest extends TestCase
 
         $mock2 = $this->getMock('React\Promise\CancellablePromiseInterface');
         $mock2
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('cancel');
 
         race([$deferred->promise(), $mock2])->cancel();

--- a/tests/FunctionSomeTest.php
+++ b/tests/FunctionSomeTest.php
@@ -209,7 +209,7 @@ class FunctionSomeTest extends TestCase
     }
 
     /** @test */
-    public function shouldCancelOtherPendingInputArrayPromisesIfEnoughPromisesFulfill()
+    public function shouldNotCancelOtherPendingInputArrayPromisesIfEnoughPromisesFulfill()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -221,14 +221,14 @@ class FunctionSomeTest extends TestCase
 
         $mock2 = $this->getMock('React\Promise\CancellablePromiseInterface');
         $mock2
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('cancel');
 
         some([$deferred->promise(), $mock2], 1);
     }
 
     /** @test */
-    public function shouldCancelOtherPendingInputArrayPromisesIfEnoughPromisesReject()
+    public function shouldNotCancelOtherPendingInputArrayPromisesIfEnoughPromisesReject()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -240,7 +240,7 @@ class FunctionSomeTest extends TestCase
 
         $mock2 = $this->getMock('React\Promise\CancellablePromiseInterface');
         $mock2
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('cancel');
 
         some([$deferred->promise(), $mock2], 2);


### PR DESCRIPTION
This reverts automatic cancellation of pending collection promises once the output promise resolves. This was introduced in 42d86b7 and was both unintended and backward incompatible.

**Note:** This is for **2.x**
