### PR TITLE
Use done() if available when resolving foreign thenables

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -15,6 +15,12 @@ function resolve($promiseOrValue = null)
             $canceller = [$promiseOrValue, 'cancel'];
         }
 
+        if (method_exists($promiseOrValue, 'done')) {
+            return new Promise(function ($resolve, $reject, $notify) use ($promiseOrValue) {
+                $promiseOrValue->done($resolve, $reject, $notify);
+            }, $canceller);
+        }
+
         return new Promise(function ($resolve, $reject, $notify) use ($promiseOrValue) {
             $promiseOrValue->then($resolve, $reject, $notify);
         }, $canceller);

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -61,6 +61,20 @@ class FunctionResolveTest extends TestCase
     }
 
     /** @test */
+    public function shouldResolveADonable()
+    {
+        $this->setExpectedException('\Exception', 'UnhandledRejectionException');
+
+        $exception = new \Exception('UnhandledRejectionException');
+
+        $donable = new SimpleRejectedTestDonable($exception);
+
+        resolve($donable)
+            ->then()
+            ->done();
+    }
+
+    /** @test */
     public function shouldResolveACancellableThenable()
     {
         $thenable = new SimpleTestCancellableThenable();

--- a/tests/fixtures/SimpleRejectedTestDonable.php
+++ b/tests/fixtures/SimpleRejectedTestDonable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace React\Promise;
+
+class SimpleRejectedTestDonable
+{
+    private $exception;
+
+    public function __construct(\Exception $exception)
+    {
+        $this->exception = $exception;
+    }
+
+    public function then(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null)
+    {
+        return new self($this->exception);
+    }
+
+    public function done(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null)
+    {
+        throw $this->exception;
+    }
+}


### PR DESCRIPTION
This adds a check to `Promise\resolve` when resolving foreign Thenables if a `done()` method exists and uses this instead of `then()`.

Ref #66
