### PR TITLE
Prevent circular references when resolving a promise with itself

### DIFF
--- a/src/LazyPromise.php
+++ b/src/LazyPromise.php
@@ -42,7 +42,11 @@ class LazyPromise implements ExtendedPromiseInterface, CancellablePromiseInterfa
         return $this->promise()->cancel();
     }
 
-    private function promise()
+    /**
+     * @internal
+     * @see Promise::settle()
+     */
+    public function promise()
     {
         if (null === $this->promise) {
             try {

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -155,6 +155,16 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
 
     private function settle(ExtendedPromiseInterface $promise)
     {
+        if ($promise instanceof LazyPromise) {
+            $promise = $promise->promise();
+        }
+
+        if ($promise === $this) {
+            $promise = new RejectedPromise(
+                new \LogicException('Cannot resolve a promise with itself.')
+            );
+        }
+
         $handlers = $this->handlers;
 
         $this->progressHandlers = $this->handlers = [];

--- a/tests/PromiseTest/ResolveTestTrait.php
+++ b/tests/PromiseTest/ResolveTestTrait.php
@@ -112,6 +112,28 @@ trait ResolveTestTrait
         $adapter->resolve(2);
     }
 
+    /**
+     * @test
+     */
+    public function resolveShouldRejectWhenResolvedWithItself()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(new \LogicException('Cannot resolve a promise with itself.'));
+
+        $adapter->promise()
+            ->then(
+                $this->expectCallableNever(),
+                $mock
+            );
+
+        $adapter->resolve($adapter->promise());
+    }
+
     /** @test */
     public function doneShouldInvokeFulfillmentHandler()
     {


### PR DESCRIPTION
When resolving a promise with itself, the promise becomes rejected with a \LogicException.

Closes #70
Ping @clue @WyriHaximus @cboden 