### PR TITLE
Support foreign thenables in reject()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -25,7 +25,7 @@ function resolve($promiseOrValue = null)
 
 function reject($promiseOrValue = null)
 {
-    if ($promiseOrValue instanceof PromiseInterface) {
+    if (method_exists($promiseOrValue, 'then')) {
         return resolve($promiseOrValue)->then(function ($value) {
             return new RejectedPromise($value);
         });

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -61,4 +61,22 @@ class FunctionRejectTest extends TestCase
                 $mock
             );
     }
+
+    /** @test */
+    public function shouldRejectAThenable()
+    {
+        $thenable = new SimpleRejectedTestThenable();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo('foo'));
+
+        reject($thenable)
+            ->then(
+                $this->expectCallableNever(),
+                $mock
+            );
+    }
 }

--- a/tests/fixtures/SimpleRejectedTestThenable.php
+++ b/tests/fixtures/SimpleRejectedTestThenable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace React\Promise;
+
+class SimpleRejectedTestThenable
+{
+    public function then(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null)
+    {
+        try {
+            if ($onRejected) {
+                $onRejected('foo');
+            }
+
+            return new self();
+        } catch (\Throwable $exception) {
+            return new RejectedPromise($exception);
+        } catch (\Exception $exception) {
+            return new RejectedPromise($exception);
+        }
+    }
+}


### PR DESCRIPTION
`resolve` supports foreign thenables (introduced in #52), so should `reject`.