### PR TITLE
Preserve the order of the array with all and map functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG for 2.x
               });
       }
       ```
+    * `all()` and `map()` functions now preserve the order of the array.
 
 * 2.4.1 (2016-05-03)
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -156,6 +156,7 @@ function map($promisesOrValues, callable $mapFunc)
 
                 foreach ($array as $i => $promiseOrValue) {
                     $cancellationQueue->enqueue($promiseOrValue);
+                    $values[$i] = null;
 
                     resolve($promiseOrValue)
                         ->then($mapFunc)

--- a/tests/FunctionAllTest.php
+++ b/tests/FunctionAllTest.php
@@ -94,4 +94,25 @@ class FunctionAllTest extends TestCase
         all(resolve(1))
             ->then($mock);
     }
+
+    /** @test */
+    public function shouldPreserveTheOrderOfArrayWhenResolvingAsyncPromises()
+    {
+        $queue = new \SplQueue();
+        $asyncPromise = new Promise(function ($resolve) use ($queue) {
+            $queue->enqueue(function () use ($resolve, $queue) {
+                $resolve(2);
+            });
+        });
+
+        $result = null;
+
+        all([resolve(1), $asyncPromise, resolve(3)])->then(function ($resolvedValues) use (&$result) {
+            $result = $resolvedValues;
+        });
+
+        call_user_func($queue->dequeue());
+
+        $this->assertSame([1, 2, 3], $result);
+    }
 }

--- a/tests/FunctionAllTest.php
+++ b/tests/FunctionAllTest.php
@@ -98,21 +98,17 @@ class FunctionAllTest extends TestCase
     /** @test */
     public function shouldPreserveTheOrderOfArrayWhenResolvingAsyncPromises()
     {
-        $queue = new \SplQueue();
-        $asyncPromise = new Promise(function ($resolve) use ($queue) {
-            $queue->enqueue(function () use ($resolve, $queue) {
-                $resolve(2);
-            });
-        });
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3]));
 
-        $result = null;
+        $deferred = new Deferred();
 
-        all([resolve(1), $asyncPromise, resolve(3)])->then(function ($resolvedValues) use (&$result) {
-            $result = $resolvedValues;
-        });
+        all([resolve(1), $deferred->promise(), resolve(3)])
+            ->then($mock);
 
-        call_user_func($queue->dequeue());
-
-        $this->assertSame([1, 2, 3], $result);
+        $deferred->resolve(2);
     }
 }

--- a/tests/FunctionMapTest.php
+++ b/tests/FunctionMapTest.php
@@ -109,6 +109,30 @@ class FunctionMapTest extends TestCase
     }
 
     /** @test */
+    public function shouldPreserveTheOrderOfArrayWhenResolvingAsyncPromises()
+    {
+        $queue = new \SplQueue();
+        $asyncPromise = new Promise(function ($resolve) use ($queue) {
+            $queue->enqueue(function () use ($resolve, $queue) {
+                $resolve(2);
+            });
+        });
+
+        $result = null;
+
+        map(
+            [resolve(1), $asyncPromise, resolve(3)],
+            $this->mapper()
+        )->then(function ($resolvedValues) use (&$result) {
+            $result = $resolvedValues;
+        });
+
+        call_user_func($queue->dequeue());
+
+        $this->assertSame([2 ,4 ,6], $result);
+    }
+
+    /** @test */
     public function shouldRejectWhenInputContainsRejection()
     {
         $mock = $this->createCallableMock();

--- a/tests/FunctionMapTest.php
+++ b/tests/FunctionMapTest.php
@@ -111,25 +111,20 @@ class FunctionMapTest extends TestCase
     /** @test */
     public function shouldPreserveTheOrderOfArrayWhenResolvingAsyncPromises()
     {
-        $queue = new \SplQueue();
-        $asyncPromise = new Promise(function ($resolve) use ($queue) {
-            $queue->enqueue(function () use ($resolve, $queue) {
-                $resolve(2);
-            });
-        });
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([2, 4, 6]));
 
-        $result = null;
+        $deferred = new Deferred();
 
         map(
-            [resolve(1), $asyncPromise, resolve(3)],
+            [resolve(1), $deferred->promise(), resolve(3)],
             $this->mapper()
-        )->then(function ($resolvedValues) use (&$result) {
-            $result = $resolvedValues;
-        });
+        )->then($mock);
 
-        call_user_func($queue->dequeue());
-
-        $this->assertSame([2 ,4 ,6], $result);
+        $deferred->resolve(2);
     }
 
     /** @test */


### PR DESCRIPTION
fixes #74 

I added the changelog entry for the 2.5.x heading (not sure if this is correct). 