### PR TITLE
Replace the queue() function with a static Queue class

### DIFF
--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -22,7 +22,7 @@ final class FulfilledPromise implements PromiseInterface
         }
 
         return new Promise(function (callable $resolve, callable $reject) use ($onFulfilled) {
-            queue()->enqueue(function () use ($resolve, $reject, $onFulfilled) {
+            Queue::enqueue(function () use ($resolve, $reject, $onFulfilled) {
                 try {
                     $resolve($onFulfilled($this->value));
                 } catch (\Throwable $exception) {
@@ -40,7 +40,7 @@ final class FulfilledPromise implements PromiseInterface
             return;
         }
 
-        queue()->enqueue(function () use ($onFulfilled) {
+        Queue::enqueue(function () use ($onFulfilled) {
             $result = $onFulfilled($this->value);
 
             if ($result instanceof PromiseInterface) {

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace React\Promise;
+
+use React\Promise\Queue\DriverInterface;
+
+final class Queue
+{
+    /**
+     * @var DriverInterface
+     */
+    private static $driver;
+
+    public static function setDriver(DriverInterface $driver = null)
+    {
+        self::$driver = $driver;
+    }
+
+    public static function getDriver()
+    {
+        if (!self::$driver) {
+            self::$driver = new Queue\SynchronousDriver();
+        }
+
+        return self::$driver;
+    }
+
+    public static function enqueue(callable $task)
+    {
+        if (!self::$driver) {
+            self::getDriver();
+        }
+
+        self::$driver->enqueue($task);
+    }
+}

--- a/src/Queue/DriverInterface.php
+++ b/src/Queue/DriverInterface.php
@@ -2,7 +2,7 @@
 
 namespace React\Promise\Queue;
 
-interface QueueInterface
+interface DriverInterface
 {
     public function enqueue(callable $task);
 }

--- a/src/Queue/SynchronousDriver.php
+++ b/src/Queue/SynchronousDriver.php
@@ -2,7 +2,7 @@
 
 namespace React\Promise\Queue;
 
-final class SynchronousQueue implements QueueInterface
+final class SynchronousDriver implements DriverInterface
 {
     private $queue = [];
 

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -22,7 +22,7 @@ final class RejectedPromise implements PromiseInterface
         }
 
         return new Promise(function (callable $resolve, callable $reject) use ($onRejected) {
-            queue()->enqueue(function () use ($resolve, $reject, $onRejected) {
+            Queue::enqueue(function () use ($resolve, $reject, $onRejected) {
                 try {
                     $resolve($onRejected($this->reason));
                 } catch (\Throwable $exception) {
@@ -36,7 +36,7 @@ final class RejectedPromise implements PromiseInterface
 
     public function done(callable $onFulfilled = null, callable $onRejected = null)
     {
-        queue()->enqueue(function () use ($onRejected) {
+        Queue::enqueue(function () use ($onRejected) {
             if (null === $onRejected) {
                 throw UnhandledRejectionException::resolve($this->reason);
             }

--- a/src/functions.php
+++ b/src/functions.php
@@ -189,21 +189,6 @@ function reduce(array $promisesOrValues, callable $reduceFunc, $initialValue = n
     }, $cancellationQueue);
 }
 
-function queue(Queue\QueueInterface $queue = null)
-{
-    static $globalQueue;
-
-    if ($queue) {
-        return ($globalQueue = $queue);
-    }
-
-    if (!$globalQueue) {
-        $globalQueue = new Queue\SynchronousQueue();
-    }
-
-    return $globalQueue;
-}
-
 /**
  * @internal
  */

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace React\Promise;
+
+class QueueTest extends TestCase
+{
+    /** @test */
+    public function canSetDriver()
+    {
+        $oldDriver = Queue::getDriver();
+
+        $newDriver = $this
+            ->getMockBuilder('React\Promise\Queue\DriverInterface')
+            ->getMock();
+
+        Queue::setDriver($newDriver);
+
+        $this->assertSame($newDriver, Queue::getDriver());
+
+        Queue::setDriver($oldDriver);
+    }
+}


### PR DESCRIPTION
We allow swapping out the queue implementation and this must be done in a bootstrap file before executing anything from react/promise.

Consider the case, were a user defines a bootstrap file in the composer.json were the queue implementation is changed.

```json
{
    "autoload": {
        "files": ["src/bootstrap.php"]
    }
}
```

The `bootstrap.php` contains the code for swapping out the queue implementation.

```php
queue(MyQueueImplementation());
```

Depending on the order in `vendor/composer/autoload_files.php`, our `functions.php` might be loaded **after** the `bootstrap.php` thus making the `queue()` function unavailable to the bootstrap file.

This patch replaces the `queue()` function by a static class which is autoloadable.

The only difference is in the API, the behavior is unchanged (note, that this feature is not released yet).

Enqueuing a task:

```php
// Old
queue()->enqueue($task);

// New
Queue::enqueue($task)
```

Swapping out the queue implementation:

```php
// Old
queue(MyQueueImplementation());

// New
Queue::setDriver(MyQueueImplementation());
```
