### PR TITLE
Fix race() to return a forever pending promise when called with an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ CHANGELOG for 3.x
       `some()`, `map()`, `reduce()`) now require an array of promises or values
       as input. Before, arrays and promises which resolve to an array were
       supported, other input types resolved to empty arrays or `null` (#35).
+    * BC break: `race()` now returns a forever pending promise when called with
+      an empty array (#83).
+      The behavior is now also in line with the ES6 specification.
     * BC break: The interfaces `PromiseInterface`, `ExtendedPromiseInterface`
       and `CancellablePromiseInterface` have been merged into a single
       `PromiseInterface` (#75).

--- a/README.md
+++ b/README.md
@@ -445,6 +445,9 @@ $promise = React\Promise\race(array $promisesOrValues);
 Initiates a competitive race that allows one winner. Returns a promise which is
 resolved in the same way the first settled promise resolves.
 
+The returned promise will become **infinitely pending** if  `$promisesOrValues`
+contains 0 items.
+
 #### any()
 
 ```php

--- a/src/functions.php
+++ b/src/functions.php
@@ -44,7 +44,7 @@ function all(array $promisesOrValues)
 function race(array $promisesOrValues)
 {
     if (!$promisesOrValues) {
-        return resolve();
+        return new Promise(function() {});
     }
 
     $cancellationQueue = new Internal\CancellationQueue();

--- a/tests/FunctionRaceTest.php
+++ b/tests/FunctionRaceTest.php
@@ -5,17 +5,11 @@ namespace React\Promise;
 class FunctionRaceTest extends TestCase
 {
     /** @test */
-    public function shouldResolveEmptyInput()
+    public function shouldReturnForeverPendingPromiseForEmptyInput()
     {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->identicalTo(null));
-
         race(
             []
-        )->then($mock);
+        )->then($this->expectCallableNever(), $this->expectCallableNever());
     }
 
     /** @test */


### PR DESCRIPTION
Fix `race()` to return a forever pending promise when called with an empty array.

Alternative for #81.
See #57 for the discussion.

Closes #57