### PR TITLE
Fix circular references when resolving with a promise which follows itself

### DIFF
--- a/tests/PromiseTest/ResolveTestTrait.php
+++ b/tests/PromiseTest/ResolveTestTrait.php
@@ -134,6 +134,33 @@ trait ResolveTestTrait
         $adapter->resolve($adapter->promise());
     }
 
+    /**
+     * @test
+     */
+    public function resolveShouldRejectWhenResolvedWithAPromiseWhichFollowsItself()
+    {
+        $adapter1 = $this->getPromiseTestAdapter();
+        $adapter2 = $this->getPromiseTestAdapter();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(new \LogicException('Cannot resolve a promise with itself.'));
+
+        $promise1 = $adapter1->promise();
+
+        $promise2 = $adapter2->promise();
+
+        $promise2->then(
+            $this->expectCallableNever(),
+            $mock
+        );
+
+        $adapter1->resolve($promise2);
+        $adapter2->resolve($promise1);
+    }
+
     /** @test */
     public function doneShouldInvokeFulfillmentHandler()
     {


### PR DESCRIPTION
**Note:** this patch is for **2.x**

This rounds up #71 preventing circular references not only when promises are resolved directly with itself but also when promises are resolved with promises which follow itself.

Currently, the following ends in an infinite loop:

```php
$d1 = new \React\Promise\Deferred();
$d2 = new \React\Promise\Deferred();

$d1->resolve($d2->promise());
$d2->resolve($d1->promise());

$d2->promise()
    ->otherwise(function(\LogicException $e) {
        assert('Cannot resolve a promise with itself.' === $e->getMessage());
    })
;
```

See also the [Travis build](https://travis-ci.org/reactphp/promise/builds/212048671) for the first commit (3524ed7) of this PR adding only a test case.