### PR TITLE
Trigger an E_USER_ERROR instead of throwing an exception from done()

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ $promise->done(callable $onFulfilled = null, callable $onRejected = null);
 Consumes the promise's ultimate value if the promise fulfills, or handles the
 ultimate error.
 
-It will cause a fatal error if either `$onFulfilled` or `$onRejected` throw or
-return a rejected promise.
+It will cause a fatal error (`E_USER_ERROR`) if either `$onFulfilled` or
+`$onRejected` throw or return a rejected promise.
 
 Since the purpose of `done()` is consumption rather than transformation,
 `done()` always returns `null`.
@@ -651,8 +651,8 @@ by the promise machinery and used to reject the promise returned by `then()`.
 
 Calling `done()` transfers all responsibility for errors to your code. If an
 error (either a thrown exception or returned rejection) escapes the
-`$onFulfilled` or `$onRejected` callbacks you provide to done, it will be
-rethrown in an uncatchable way causing a fatal error.
+`$onFulfilled` or `$onRejected` callbacks you provide to `done()`, it will cause
+a fatal error.
 
 ```php
 function getJsonResult()

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -41,7 +41,13 @@ final class FulfilledPromise implements PromiseInterface
         }
 
         enqueue(function () use ($onFulfilled) {
-            $result = $onFulfilled($this->value);
+            try {
+                $result = $onFulfilled($this->value);
+            } catch (\Throwable $exception) {
+                return fatalError($exception);
+            } catch (\Exception $exception) {
+                return fatalError($exception);
+            }
 
             if ($result instanceof PromiseInterface) {
                 $result->done();

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -38,13 +38,23 @@ final class RejectedPromise implements PromiseInterface
     {
         enqueue(function () use ($onRejected) {
             if (null === $onRejected) {
-                throw UnhandledRejectionException::resolve($this->reason);
+                return fatalError(
+                    UnhandledRejectionException::resolve($this->reason)
+                );
             }
 
-            $result = $onRejected($this->reason);
+            try {
+                $result = $onRejected($this->reason);
+            } catch (\Throwable $exception) {
+                return fatalError($exception);
+            } catch (\Exception $exception) {
+                return fatalError($exception);
+            }
 
             if ($result instanceof self) {
-                throw UnhandledRejectionException::resolve($result->reason);
+                return fatalError(
+                    UnhandledRejectionException::resolve($result->reason)
+                );
             }
 
             if ($result instanceof PromiseInterface) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -206,6 +206,22 @@ function enqueue(callable $task)
 /**
  * @internal
  */
+function fatalError($error)
+{
+    try {
+        trigger_error($error, E_USER_ERROR);
+    } catch (\Throwable $e) {
+        set_error_handler(null);
+        trigger_error($error, E_USER_ERROR);
+    } catch (\Exception $e) {
+        set_error_handler(null);
+        trigger_error($error, E_USER_ERROR);
+    }
+}
+
+/**
+ * @internal
+ */
 function _checkTypehint(callable $callback, $object)
 {
     if (!is_object($object)) {

--- a/tests/ErrorCollector.php
+++ b/tests/ErrorCollector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace React\Promise;
+
+final class ErrorCollector
+{
+    private $errors = [];
+
+    public function start()
+    {
+        $errors = [];
+
+        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) use (&$errors) {
+            $errors[] = compact('errno', 'errstr', 'errfile', 'errline', 'errcontext');
+        });
+
+        $this->errors = &$errors;
+    }
+
+    public function stop()
+    {
+        $errors = $this->errors;
+        $this->errors = [];
+
+        restore_error_handler();
+
+        return $errors;
+    }
+}

--- a/tests/PromiseTest/PromiseFulfilledTestTrait.php
+++ b/tests/PromiseTest/PromiseFulfilledTestTrait.php
@@ -2,6 +2,8 @@
 
 namespace React\Promise\PromiseTest;
 
+use React\Promise\ErrorCollector;
+
 trait PromiseFulfilledTestTrait
 {
     /**
@@ -212,29 +214,43 @@ trait PromiseFulfilledTestTrait
     }
 
     /** @test */
-    public function doneShouldThrowExceptionThrownFulfillmentHandlerForFulfilledPromise()
+    public function doneShouldTriggerFatalErrorThrownFulfillmentHandlerForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $this->setExpectedException('\Exception', 'UnhandledRejectionException');
-
         $adapter->resolve(1);
+
+        $errorCollector = new ErrorCollector();
+        $errorCollector->start();
+
         $this->assertNull($adapter->promise()->done(function () {
-            throw new \Exception('UnhandledRejectionException');
+            throw new \Exception('Unhandled Rejection');
         }));
+
+        $errors = $errorCollector->stop();
+        
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowUnhandledRejectionExceptionWhenFulfillmentHandlerRejectsForFulfilledPromise()
+    public function doneShouldTriggerFatalErrorUnhandledRejectionExceptionWhenFulfillmentHandlerRejectsForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $this->setExpectedException('React\\Promise\\UnhandledRejectionException');
-
         $adapter->resolve(1);
+
+        $errorCollector = new ErrorCollector();
+        $errorCollector->start();
+
         $this->assertNull($adapter->promise()->done(function () {
             return \React\Promise\reject();
         }));
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection: null', $errors[0]['errstr']);
     }
 
     /** @test */

--- a/tests/PromiseTest/RejectTestTrait.php
+++ b/tests/PromiseTest/RejectTestTrait.php
@@ -145,61 +145,86 @@ trait RejectTestTrait
     }
 
     /** @test */
-    public function doneShouldThrowExceptionThrownByRejectionHandler()
+    public function doneShouldTriggerFatalErrorExceptionThrownByRejectionHandler()
     {
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
+
         $adapter = $this->getPromiseTestAdapter();
 
-        $this->setExpectedException('\Exception', 'UnhandledRejectionException');
-
         $this->assertNull($adapter->promise()->done(null, function () {
-            throw new \Exception('UnhandledRejectionException');
+            throw new \Exception('Unhandled Rejection');
         }));
         $adapter->reject(1);
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowUnhandledRejectionExceptionWhenRejectedWithNonException()
+    public function doneShouldTriggerFatalErrorUnhandledRejectionExceptionWhenRejectedWithNonException()
     {
-        $adapter = $this->getPromiseTestAdapter();
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
 
-        $this->setExpectedException('React\\Promise\\UnhandledRejectionException');
+        $adapter = $this->getPromiseTestAdapter();
 
         $this->assertNull($adapter->promise()->done());
         $adapter->reject(1);
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection: 1', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowUnhandledRejectionExceptionWhenRejectionHandlerRejects()
+    public function doneShouldTriggerFatalErrorUnhandledRejectionExceptionWhenRejectionHandlerRejects()
     {
-        $adapter = $this->getPromiseTestAdapter();
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
 
-        $this->setExpectedException('React\\Promise\\UnhandledRejectionException');
+        $adapter = $this->getPromiseTestAdapter();
 
         $this->assertNull($adapter->promise()->done(null, function () {
             return \React\Promise\reject();
         }));
         $adapter->reject(1);
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection: null', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowRejectionExceptionWhenRejectionHandlerRejectsWithException()
+    public function doneShouldTriggerFatalErrorRejectionExceptionWhenRejectionHandlerRejectsWithException()
     {
-        $adapter = $this->getPromiseTestAdapter();
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
 
-        $this->setExpectedException('\Exception', 'UnhandledRejectionException');
+        $adapter = $this->getPromiseTestAdapter();
 
         $this->assertNull($adapter->promise()->done(null, function () {
-            return \React\Promise\reject(new \Exception('UnhandledRejectionException'));
+            return \React\Promise\reject(new \Exception('Unhandled Rejection'));
         }));
         $adapter->reject(1);
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowUnhandledRejectionExceptionWhenRejectionHandlerRetunsPendingPromiseWhichRejectsLater()
+    public function doneShouldTriggerFatalErrorUnhandledRejectionExceptionWhenRejectionHandlerRetunsPendingPromiseWhichRejectsLater()
     {
-        $adapter = $this->getPromiseTestAdapter();
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
 
-        $this->setExpectedException('React\\Promise\\UnhandledRejectionException');
+        $adapter = $this->getPromiseTestAdapter();
 
         $d = new Deferred();
         $promise = $d->promise();
@@ -209,25 +234,37 @@ trait RejectTestTrait
         }));
         $adapter->reject(1);
         $d->reject(1);
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection: 1', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowExceptionProvidedAsRejectionValue()
+    public function doneShouldTriggerFatalErrorExceptionProvidedAsRejectionValue()
     {
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
+
         $adapter = $this->getPromiseTestAdapter();
 
-        $this->setExpectedException('\Exception', 'UnhandledRejectionException');
-
         $this->assertNull($adapter->promise()->done());
-        $adapter->reject(new \Exception('UnhandledRejectionException'));
+        $adapter->reject(new \Exception('Unhandled Rejection'));
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowWithDeepNestingPromiseChains()
+    public function doneShouldTriggerFatalErrorWithDeepNestingPromiseChains()
     {
-        $this->setExpectedException('\Exception', 'UnhandledRejectionException');
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
 
-        $exception = new \Exception('UnhandledRejectionException');
+        $exception = new \Exception('Unhandled Rejection');
 
         $d = new Deferred();
 
@@ -245,6 +282,11 @@ trait RejectTestTrait
         $result->done();
 
         $d->resolve();
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertEquals((string) $exception, $errors[0]['errstr']);
     }
 
     /** @test */

--- a/tests/PromiseTest/ResolveTestTrait.php
+++ b/tests/PromiseTest/ResolveTestTrait.php
@@ -177,29 +177,41 @@ trait ResolveTestTrait
     }
 
     /** @test */
-    public function doneShouldThrowExceptionThrownFulfillmentHandler()
+    public function doneShouldTriggerFatalErrorExceptionThrownFulfillmentHandler()
     {
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
+
         $adapter = $this->getPromiseTestAdapter();
 
-        $this->setExpectedException('\Exception', 'UnhandledRejectionException');
-
         $this->assertNull($adapter->promise()->done(function () {
-            throw new \Exception('UnhandledRejectionException');
+            throw new \Exception('Unhandled Rejection');
         }));
         $adapter->resolve(1);
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
-    public function doneShouldThrowUnhandledRejectionExceptionWhenFulfillmentHandlerRejects()
+    public function doneShouldTriggerFatalErrorUnhandledRejectionExceptionWhenFulfillmentHandlerRejects()
     {
-        $adapter = $this->getPromiseTestAdapter();
+        $errorCollector = new Promise\ErrorCollector();
+        $errorCollector->start();
 
-        $this->setExpectedException('React\\Promise\\UnhandledRejectionException');
+        $adapter = $this->getPromiseTestAdapter();
 
         $this->assertNull($adapter->promise()->done(function () {
             return \React\Promise\reject();
         }));
         $adapter->resolve(1);
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains('Unhandled Rejection: null', $errors[0]['errstr']);
     }
 
     /** @test */


### PR DESCRIPTION
If an error (either a thrown exception or returned rejection) escapes the `done()` callbacks, it will now cause a fatal error by using `trigger_error()` with `E_USER_ERROR` instead of (re)throwing.

Because promise resolution is synchronous, those exceptions bubbled up to the
`reject()` call which mixed resolution and consumption parts.

Closes #88 