### PR TITLE
Follower cancellation propagation

### DIFF
--- a/tests/PromiseTest/CancelTestTrait.php
+++ b/tests/PromiseTest/CancelTestTrait.php
@@ -228,4 +228,72 @@ trait CancelTestTrait
 
         $adapter->promise()->cancel();
     }
+
+    /** @test */
+    public function cancelShouldTriggerCancellerWhenFollowerCancels()
+    {
+        $adapter1 = $this->getPromiseTestAdapter($this->expectCallableOnce());
+
+        $root = $adapter1->promise();
+
+        $adapter2 = $this->getPromiseTestAdapter($this->expectCallableOnce());
+
+        $follower = $adapter2->promise();
+        $adapter2->resolve($root);
+
+        $follower->cancel();
+    }
+
+    /** @test */
+    public function cancelShouldNotTriggerCancellerWhenCancellingOnlyOneFollower()
+    {
+        $adapter1 = $this->getPromiseTestAdapter($this->expectCallableNever());
+
+        $root = $adapter1->promise();
+
+        $adapter2 = $this->getPromiseTestAdapter($this->expectCallableOnce());
+
+        $follower1 = $adapter2->promise();
+        $adapter2->resolve($root);
+
+        $adapter3 = $this->getPromiseTestAdapter($this->expectCallableNever());
+        $adapter3->resolve($root);
+
+        $follower1->cancel();
+    }
+
+    /** @test */
+    public function cancelCalledOnFollowerShouldOnlyCancelWhenAllChildrenAndFollowerCancelled()
+    {
+        $adapter1 = $this->getPromiseTestAdapter($this->expectCallableOnce());
+
+        $root = $adapter1->promise();
+
+        $child = $root->then();
+
+        $adapter2 = $this->getPromiseTestAdapter($this->expectCallableOnce());
+
+        $follower = $adapter2->promise();
+        $adapter2->resolve($root);
+
+        $follower->cancel();
+        $child->cancel();
+    }
+
+    /** @test */
+    public function cancelShouldNotTriggerCancellerWhenCancellingFollowerButNotChildren()
+    {
+        $adapter1 = $this->getPromiseTestAdapter($this->expectCallableNever());
+
+        $root = $adapter1->promise();
+
+        $root->then();
+
+        $adapter2 = $this->getPromiseTestAdapter($this->expectCallableOnce());
+
+        $follower = $adapter2->promise();
+        $adapter2->resolve($root);
+
+        $follower->cancel();
+    }
 }


### PR DESCRIPTION
This PR implements cancellation propagation for promises following another promise in the same way currently implemented for child promises created by `then()`.

Consider the following code:

```php
$root = new Promise(/* ...*/);

$child = $root->then();

$follower = new Promise(function($resolve) use ($root) {
    $resolve($root);
});
```

The behaviour is identical regarding resolution. Both `$child` and `$follower` follow `$root` which means, both will be fulfilled or rejected in the same way as `$root`.

The behaviour is different regarding cancellation though. 

* If `$child->cancel()` is called, `$root` is cancelled although `$follower` is still interested in the result.
* If `$follower->cancel()` is called, cancellation is not propagated to `$root`.

This PR fixes that, so `$follower` propagates cancellation in the same way as `$child`.