### PR TITLE
[WIP] throttle

### DIFF
--- a/tests/FunctionThrottleTest.php
+++ b/tests/FunctionThrottleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace React\Promise;
+
+class FunctionThrottleTest extends TestCase
+{
+
+    /** @test */
+    public function shouldResolvePromisesArrayWithLessThenConcurrency()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3]));
+
+        throttle([resolve(1), resolve(2), resolve(3)], 10)
+            ->then($mock);
+    }
+
+    /** @test */
+    public function shouldResolvePromisesArrayWithMultipleOfConcurrency()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3, 4, 5, 6]));
+
+        throttle([resolve(1), resolve(2), resolve(3), resolve(4), resolve(5), resolve(6)], 2)
+            ->then($mock);
+    }
+
+    /** @test */
+    public function shouldResolvePromisesArrayWithMoreThenConcurrency()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3, 4, 5, 6, 7]));
+
+        throttle([resolve(1), resolve(2), resolve(3), resolve(4), resolve(5), resolve(6), resolve(7)], 2)
+            ->then($mock);
+    }
+}


### PR DESCRIPTION
This PR introduces a new function `throttle`.

`throttle` behaves like `all`, but limits the number of concurrent requests by a passed parameter.

One use case for throttles are if you are sending a bunch of api-requests but don't want to hit rate-limits or if you want to have more control over your systems resources.

This PR is WIP as I need to:

- [ ] also run the tests that pass for `all`
- [ ] introduce tests that actually check if the concurrency-limit is being kept
- [ ] update the projects readme to reflect this new function

Before doing that I wanted to check if this is in scope of this repo anyway. If you feel like this is out of scope, I will create another package for that.

The implementation is somewhat naive. Instead of creating a queue and starting another promise whenever one item finishes, I made a chain, where every promise has a succeeding one. That has the downside that the concurrency-limit may not always be used ideally. It is guaranteed to be not overused, but situations may exist, where you are (for example) only using 8 instead of 10 promises at the same time.

Any feedback / ideas / help is very welcome!