### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35"
+        "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -37,11 +37,12 @@ class FulfilledPromiseTest extends TestCase
         ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
     public function shouldThrowExceptionIfConstructedWithAPromise()
     {
-        $this->setExpectedException('\InvalidArgumentException');
-
         return new FulfilledPromise(new FulfilledPromise());
     }
 }

--- a/tests/Internal/CancellationQueueTest.php
+++ b/tests/Internal/CancellationQueueTest.php
@@ -74,11 +74,13 @@ class CancellationQueueTest extends TestCase
         $cancellationQueue();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException Exception
+     * @expectedExceptionMessage test
+     */
     public function rethrowsExceptionsThrownFromCancel()
     {
-        $this->setExpectedException('\Exception', 'test');
-
         $mock = $this->createCallableMock();
         $mock
             ->expects($this->once())

--- a/tests/Internal/QueueTest.php
+++ b/tests/Internal/QueueTest.php
@@ -29,11 +29,13 @@ class QueueTest extends TestCase
         $queue->enqueue($task);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException Exception
+     * @expectedException test
+     */
     public function rethrowsExceptionsThrownFromTasks()
     {
-        $this->setExpectedException('\Exception', 'test');
-
         $mock = $this->createCallableMock();
         $mock
             ->expects($this->once())

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -37,11 +37,12 @@ class RejectedPromiseTest extends TestCase
         ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
     public function shouldThrowExceptionIfConstructedWithAPromise()
     {
-        $this->setExpectedException('\InvalidArgumentException');
-
         return new RejectedPromise(new RejectedPromise());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace React\Promise;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
 {
     public function expectCallableExactly($amount)
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.