### PR TITLE
Documentation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,10 +447,10 @@ if `$promisesOrValues` contains 0 items.
 $promise = React\Promise\some(array $promisesOrValues, integer $howMany);
 ```
 
-Returns a promise that will resolve when `$howMany` of the supplied items in
-`$promisesOrValues` resolve. The resolution value of the returned promise
-will be an array of length `$howMany` containing the resolution values of the
-triggering items.
+Returns a promise that will resolve when at least `$howMany` of the supplied items in
+`$promisesOrValues` fulfill. The resolution value of the returned promise
+will be an array of length `$howMany` containing the resolution values of
+`$howMany` fulfilled promises that were resolved first.
 
 The returned promise will reject if it becomes impossible for `$howMany` items
 to resolve (that is, when `(count($promisesOrValues) - $howMany) + 1` items


### PR DESCRIPTION
This PR provides some suggestion for documentation improvement:

### `Promise\race()`. 
> Returns a promise which is resolved in the same way the first settled promise resolves

Word `resolves` confused me that `race()` returns a promise that resolves once the first promise from the set resolves. But actually, it resolves once the first promise settles. If the settled promise resolves the resulting promise resolves with its resolution value, otherwise it resolves with a rejection reason.


### `Promise\some()`
It is not explicitly said if it expects the *exact* number of promises to be resolved or *at least* of this number. I've also added that the resolution value of the resulting promise contains resolution values from the promises that were resolved **first**.


Maybe these suggestions look like *salt is salty*, but I think that documentation should be as explicit as possible.