### PR TITLE
Improve memory consumption by only passing resolver args to resolver and canceller if callback requires them

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -221,18 +221,36 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
 
     private function call(callable $callback)
     {
+        // Use reflection to inspect number of arguments expected by this callback.
+        // We did some careful benchmarking here: Using reflection to avoid unneeded
+        // function arguments is actually faster than blindly passing them.
+        // Also, this helps avoiding unnecessary function arguments in the call stack
+        // if the callback creates an Exception (creating garbage cycles).
+        if (is_array($callback)) {
+            $ref = new \ReflectionMethod($callback[0], $callback[1]);
+        } elseif (is_object($callback) && !$callback instanceof \Closure) {
+            $ref = new \ReflectionMethod($callback, '__invoke');
+        } else {
+            $ref = new \ReflectionFunction($callback);
+        }
+        $args = $ref->getNumberOfParameters();
+
         try {
-            $callback(
-                function ($value = null) {
-                    $this->resolve($value);
-                },
-                function ($reason = null) {
-                    $this->reject($reason);
-                },
-                function ($update = null) {
-                    $this->notify($update);
-                }
-            );
+            if ($args === 0) {
+                $callback();
+            } else {
+                $callback(
+                    function ($value = null) {
+                        $this->resolve($value);
+                    },
+                    function ($reason = null) {
+                        $this->reject($reason);
+                    },
+                    function ($update = null) {
+                        $this->notify($update);
+                    }
+                );
+            }
         } catch (\Throwable $e) {
             $this->reject($e);
         } catch (\Exception $e) {

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -49,6 +49,18 @@ class PromiseTest extends TestCase
     }
 
     /** @test */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfResolverThrowsException()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () {
+            throw new \Exception('foo');
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
     public function shouldFulfillIfFullfilledWithSimplePromise()
     {
         $adapter = $this->getPromiseTestAdapter();

--- a/tests/PromiseTest/CancelTestTrait.php
+++ b/tests/PromiseTest/CancelTestTrait.php
@@ -14,15 +14,30 @@ trait CancelTestTrait
     /** @test */
     public function cancelShouldCallCancellerWithResolverArguments()
     {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->isType('callable'), $this->isType('callable'), $this->isType('callable'));
-
-        $adapter = $this->getPromiseTestAdapter($mock);
+        $args = null;
+        $adapter = $this->getPromiseTestAdapter(function ($resolve, $reject, $notify) use (&$args) {
+            $args = func_get_args();
+        });
 
         $adapter->promise()->cancel();
+
+        $this->assertCount(3, $args);
+        $this->assertTrue(is_callable($args[0]));
+        $this->assertTrue(is_callable($args[1]));
+        $this->assertTrue(is_callable($args[2]));
+    }
+
+    /** @test */
+    public function cancelShouldCallCancellerWithoutArgumentsIfNotAccessed()
+    {
+        $args = null;
+        $adapter = $this->getPromiseTestAdapter(function () use (&$args) {
+            $args = func_num_args();
+        });
+
+        $adapter->promise()->cancel();
+
+        $this->assertSame(0, $args);
     }
 
     /** @test */


### PR DESCRIPTION
While debugging some very odd memory issues in a live application, I noticed that this component shows some unexpected memory consumption and memory would not immediately be freed as expected when a pending promise is cancelled. Let's not call this a "memory leak", because memory was eventually freed, but this clearly caused some unexpected and significant memory growth.

I've used the following script to demonstrate unreasonable memory growth:

```php
<?php

use React\Promise\Promise;

require __DIR__ . '/vendor/autoload.php';

for ($i = 0; $i < 1000000; ++$i) {
    $time = time();
    $promise = new Promise(function () { }, function () use ($time) {
        throw new Exception();
    });
    $promise->cancel();
}

var_dump(memory_get_usage());
var_dump(gc_collect_cycles());
```

Initially this peaked somewhere around 15 MB on my system taking 3.4s. After applying this patch, this script reports a constant memory consumption of around 0.7 MB taking 1.8s

Empirical evidence suggests that many common use cases do not use the `$reject` (etc.) arguments and instead simply throw an `Exception`. The Promise class now uses reflection to check whether the `$resolver` and `$canceller` functions actually define any arguments and if they are not expected, doesn't actually pass them. This does involve some minor runtime overhead for using reflection, but this is actually compensated by not passing any closure arguments (1M invocations that do no use arguments show ~40% performance improvements, 1M invocations that do use arguments show a ~3% performance degradation).

More importantly, not passing these arguments has the side effect of these arguments not showing up in the call stack anymore. This is particularly important when throwing an Exception, as it would otherwise keep a reference to the promise instance in its call stack (while the promise stores the reference to this exception) and as such would cause a cyclic garbage reference.

Previously, these cyclic garbage references were eventually freed by the cyclic garbage collector after accumulating around 10000 entries with somewhere between 8MB to 15 MB. These can now be freed immediately and thus no longer cause any unexpected memory growth. This implementation includes some of the ideas discussed in https://github.com/reactphp/promise-timer/pull/32, https://github.com/reactphp/promise/issues/46 and https://github.com/reactphp/socket/pull/113.

Note that this PR does not resolve *all* unexpected memory issues. However, it addresses a very common problem for many consumers of this library and makes many of the higher level work-arounds obsolete. My vote would to be get this in here now as it addresses a relevant memory issue and eventually address any additional issues on top of this. :shipit: 