### PR TITLE
Recommend rejecting promises by throwing an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,15 +372,17 @@ $resolver = function (callable $resolve, callable $reject, callable $notify) {
     // along the way if you want/need.
 
     $resolve($awesomeResult);
+    // or throw new Exception('Promise rejected');
     // or $resolve($anotherPromise);
     // or $reject($nastyError);
     // or $notify($progressNotification);
 };
 
-$canceller = function (callable $resolve, callable $reject, callable $progress) {
+$canceller = function () {
     // Cancel/abort any running operations like network connections, streams etc.
 
-    $reject(new \Exception('Promise cancelled'));
+    // Reject promise by throwing an exception
+    throw new Exception('Promise cancelled');
 };
 
 $promise = new React\Promise\Promise($resolver, $canceller);
@@ -394,7 +396,8 @@ function which both will be called with 3 arguments:
     When called with a non-promise value, fulfills promise with that value.
     When called with another promise, e.g. `$resolve($otherPromise)`, promise's
     fate will be equivalent to that of `$otherPromise`.
-  * `$reject($reason)` - Function that rejects the promise.
+  * `$reject($reason)` - Function that rejects the promise. It is recommended to
+    just throw an exception instead of using `$reject()`.
   * `$notify($update)` - Deprecated function that issues progress events for the promise.
 
 If the resolver or canceller throw an exception, the promise will be rejected


### PR DESCRIPTION
After #113 is in, we should recommend rejecting a promise by simply throwing an exception instead of using `$reject()`.