### PR TITLE
Improve memory consumption by using static resolve and reject callback without binding to promise

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -146,15 +146,6 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
         };
     }
 
-    private function resolve($value = null)
-    {
-        if (null !== $this->result) {
-            return;
-        }
-
-        $this->settle(resolve($value));
-    }
-
     private function reject($reason = null)
     {
         if (null !== $this->result) {
@@ -228,21 +219,73 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
             if ($args === 0) {
                 $callback();
             } else {
+                // keep a reference to this promise instance for the static resolve/reject functions.
+                // see also resolveFunction() and rejectFunction() for more details.
+                $target =& $this;
+
                 $callback(
-                    function ($value = null) {
-                        $this->resolve($value);
-                    },
-                    function ($reason = null) {
-                        $this->reject($reason);
-                    },
-                    self::notifier($this->progressHandlers)
+                    self::resolveFunction($target),
+                    self::rejectFunction($target),
+                    self::notifyFunction($this->progressHandlers)
                 );
             }
         } catch (\Throwable $e) {
+            $target = null;
             $this->reject($e);
         } catch (\Exception $e) {
+            $target = null;
             $this->reject($e);
         }
+    }
+
+    /**
+     * Creates a static resolver callback that is not bound to a promise instance.
+     *
+     * Moving the closure creation to a static method allows us to create a
+     * callback that is not bound to a promise instance. By passing the target
+     * promise instance by reference, we can still execute its resolving logic
+     * and still clear this reference when settling the promise. This helps
+     * avoiding garbage cycles if any callback creates an Exception.
+     *
+     * These assumptions are covered by the test suite, so if you ever feel like
+     * refactoring this, go ahead, any alternative suggestions are welcome!
+     *
+     * @param Promise $target
+     * @return callable
+     */
+    private static function resolveFunction(self &$target)
+    {
+        return function ($value = null) use (&$target) {
+            if ($target !== null) {
+                $target->settle(resolve($value));
+                $target = null;
+            }
+        };
+    }
+
+    /**
+     * Creates a static rejection callback that is not bound to a promise instance.
+     *
+     * Moving the closure creation to a static method allows us to create a
+     * callback that is not bound to a promise instance. By passing the target
+     * promise instance by reference, we can still execute its rejection logic
+     * and still clear this reference when settling the promise. This helps
+     * avoiding garbage cycles if any callback creates an Exception.
+     *
+     * These assumptions are covered by the test suite, so if you ever feel like
+     * refactoring this, go ahead, any alternative suggestions are welcome!
+     *
+     * @param Promise $target
+     * @return callable
+     */
+    private static function rejectFunction(self &$target)
+    {
+        return function ($reason = null) use (&$target) {
+            if ($target !== null) {
+                $target->reject($reason);
+                $target = null;
+            }
+        };
     }
 
     /**
@@ -260,7 +303,7 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
      * @param array $progressHandlers
      * @return callable
      */
-    private static function notifier(&$progressHandlers)
+    private static function notifyFunction(&$progressHandlers)
     {
         return function ($update = null) use (&$progressHandlers) {
             foreach ($progressHandlers as $handler) {

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -49,7 +49,19 @@ class PromiseTest extends TestCase
     }
 
     /** @test */
-    public function shouldRejectWithoutCreatingGarbageCyclesIfResolverThrowsException()
+    public function shouldResolveWithoutCreatingGarbageCyclesIfResolverResolvesWithException()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function ($resolve) {
+            $resolve(new \Exception('foo'));
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfResolverThrowsExceptionWithoutResolver()
     {
         gc_collect_cycles();
         $promise = new Promise(function () {
@@ -60,20 +72,36 @@ class PromiseTest extends TestCase
         $this->assertSame(0, gc_collect_cycles());
     }
 
-    /**
-     * test that checks number of garbage cycles after throwing from a resolver
-     * that has its arguments explicitly set to null (reassigned arguments only
-     * show up in the stack trace in PHP 7, so we can't test this on legacy PHP)
-     *
-     * @test
-     * @requires PHP 7
-     * @link https://3v4l.org/OiDr4
-     */
-    public function shouldRejectWithoutCreatingGarbageCyclesIfResolverThrowsExceptionWithResolveAndRejectUnset()
+    /** @test */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfResolverRejectsWithException()
     {
         gc_collect_cycles();
         $promise = new Promise(function ($resolve, $reject) {
-            $resolve = $reject = null;
+            $reject(new \Exception('foo'));
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerRejectsWithException()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function ($resolve, $reject) { }, function ($resolve, $reject) {
+            $reject(new \Exception('foo'));
+        });
+        $promise->cancel();
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfResolverThrowsException()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function ($resolve, $reject) {
             throw new \Exception('foo');
         });
         unset($promise);


### PR DESCRIPTION
This builds on top of the implementation approach in #115 and the ideas discussed in #46.

The `$resolve` and `$reject` callbacks passed to the resolver and cancellation functions of each promise now no longer cause a cyclic garbage reference in any exception trace as discussed in #46. This builds on top of the work done in #113. If you do not access any arguments, this PR has no effect (also no performance or memory penalty).

If you do access any of the arguments, you no longer have to care about these functions memory wise, as they will no longer cause a cyclic garbage reference. A similar patch has been introduced for the `$progress` callback in #115 and this means this now consistently applies to all callbacks.

Invoking the benchmarking example from #113 shows that this has little effect on performance (1M invocations that do no use arguments show no performance improvements, 1M invocations that do use arguments show a ~4% performance degradation).

This PR actually includes a test that shows how garbage memory references are no longer an issue in any supported PHP version and how these functions no longer cause any such references on their own (unlike the previous test in #115 this means that this requires no effort on the consumer side anymore).