### PR TITLE
Improve memory consumption for pending promises by using static internal callbacks without binding to self

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -61,7 +61,7 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
             return $this->result->done($onFulfilled, $onRejected, $onProgress);
         }
 
-        $this->handlers[] = function (ExtendedPromiseInterface $promise) use ($onFulfilled, $onRejected) {
+        $this->handlers[] = static function (ExtendedPromiseInterface $promise) use ($onFulfilled, $onRejected) {
             $promise
                 ->done($onFulfilled, $onRejected);
         };
@@ -73,7 +73,7 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
 
     public function otherwise(callable $onRejected)
     {
-        return $this->then(null, function ($reason) use ($onRejected) {
+        return $this->then(null, static function ($reason) use ($onRejected) {
             if (!_checkTypehint($onRejected, $reason)) {
                 return new RejectedPromise($reason);
             }
@@ -84,11 +84,11 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
 
     public function always(callable $onFulfilledOrRejected)
     {
-        return $this->then(function ($value) use ($onFulfilledOrRejected) {
+        return $this->then(static function ($value) use ($onFulfilledOrRejected) {
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
                 return $value;
             });
-        }, function ($reason) use ($onFulfilledOrRejected) {
+        }, static function ($reason) use ($onFulfilledOrRejected) {
             return resolve($onFulfilledOrRejected())->then(function () use ($reason) {
                 return new RejectedPromise($reason);
             });
@@ -116,7 +116,7 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
     {
         return function ($resolve, $reject, $notify) use ($onFulfilled, $onRejected, $onProgress) {
             if ($onProgress) {
-                $progressHandler = function ($update) use ($notify, $onProgress) {
+                $progressHandler = static function ($update) use ($notify, $onProgress) {
                     try {
                         $notify($onProgress($update));
                     } catch (\Throwable $e) {
@@ -129,7 +129,7 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
                 $progressHandler = $notify;
             }
 
-            $this->handlers[] = function (ExtendedPromiseInterface $promise) use ($onFulfilled, $onRejected, $resolve, $reject, $progressHandler) {
+            $this->handlers[] = static function (ExtendedPromiseInterface $promise) use ($onFulfilled, $onRejected, $resolve, $reject, $progressHandler) {
                 $promise
                     ->then($onFulfilled, $onRejected)
                     ->done($resolve, $reject, $progressHandler);

--- a/tests/DeferredTest.php
+++ b/tests/DeferredTest.php
@@ -76,4 +76,37 @@ class DeferredTest extends TestCase
 
         $this->assertSame(0, gc_collect_cycles());
     }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingDeferred()
+    {
+        gc_collect_cycles();
+        $deferred = new Deferred();
+        $deferred->promise();
+        unset($deferred);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingDeferredWithUnusedCanceller()
+    {
+        gc_collect_cycles();
+        $deferred = new Deferred(function () { });
+        $deferred->promise();
+        unset($deferred);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingDeferredWithNoopCanceller()
+    {
+        gc_collect_cycles();
+        $deferred = new Deferred(function () { });
+        $deferred->promise()->cancel();
+        unset($deferred);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
 }

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -47,4 +47,30 @@ class FulfilledPromiseTest extends TestCase
 
         return new FulfilledPromise(new FulfilledPromise());
     }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToFulfilledPromiseWithAlwaysFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new FulfilledPromise(1);
+        $promise->always(function () {
+            throw new \RuntimeException();
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToFulfilledPromiseWithThenFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new FulfilledPromise(1);
+        $promise = $promise->then(function () {
+            throw new \RuntimeException();
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
 }

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -191,6 +191,72 @@ class PromiseTest extends TestCase
         $promise->cancel();
     }
 
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromise()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithThenFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->then()->then()->then();
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithDoneFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->done();
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithOtherwiseFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->otherwise(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithAlwaysFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->always(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithProgressFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->then(null, null, function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
     /** @test */
     public function shouldFulfillIfFullfilledWithSimplePromise()
     {

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -47,4 +47,30 @@ class RejectedPromiseTest extends TestCase
 
         return new RejectedPromise(new RejectedPromise());
     }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToRejectedPromiseWithAlwaysFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new RejectedPromise(1);
+        $promise->always(function () {
+            throw new \RuntimeException();
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToRejectedPromiseWithThenFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new RejectedPromise(1);
+        $promise = $promise->then(null, function () {
+            throw new \RuntimeException();
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
 }


### PR DESCRIPTION
All previous changes that landed in https://github.com/reactphp/promise/releases/tag/v2.6.0 improved memory consumption for settled promises somewhat. Similarly, this PR addresses memory consumption for pending promises that are no longer referenced.

```php
<?php

use React\Promise\Promise;

require __DIR__ . '/vendor/autoload.php';

for ($i = 0; $i < 1000000; ++$i) {
    $promise = new Promise(function () { });
    $promise->then('var_dump');
    unset($promise);
}

var_dump(memory_get_usage());
var_dump(gc_collect_cycles());
```

Initially this peaked somewhere around 8 MB on my system taking 4s. After applying this patch, this script reports a constant memory consumption of around 0.6 MB taking 1.8s

Note that this PR does not resolve *all* unexpected memory issues. However, it addresses a rather common problem for some consumers of this library and makes many of the higher level work-arounds obsolete. My vote would to be get this in here now as it addresses a relevant memory issue and eventually address any additional issues on top of this. :shipit: 

Builds on top of #123