### PR TITLE
Fix file_exists warning when resolving with long strings

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -8,6 +8,8 @@ function resolve($promiseOrValue = null)
         return $promiseOrValue;
     }
 
+    // Check is_object() first to avoid method_exists() triggering
+    // class autoloaders if $promiseOrValue is a string.
     if (is_object($promiseOrValue) && method_exists($promiseOrValue, 'then')) {
         $canceller = null;
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,7 +8,7 @@ function resolve($promiseOrValue = null)
         return $promiseOrValue;
     }
 
-    if (method_exists($promiseOrValue, 'then')) {
+    if (is_object($promiseOrValue) && method_exists($promiseOrValue, 'then')) {
         $canceller = null;
 
         if (method_exists($promiseOrValue, 'cancel')) {


### PR DESCRIPTION
When resolving a promise with a long string, the following may happen:

* method_exists is called
* This triggers the class autoloader to check for a class by that name
* The class autoloader will use file_exists to check for a file by that name
* file_exists emits a warning: Warning: file_exists(): File name is longer than the maximum allowed path length on this platform ([...])

The method_exists() check only makes sense for objects, since further down the call `$promiseOrValue->then(...)` is made. Static `then` methods aren't supported anyway.