### PR TITLE
Improve performance by prefixing all global functions calls with \ to skip the look up and resolve process and go straight to the global function

### DIFF
--- a/src/CancellationQueue.php
+++ b/src/CancellationQueue.php
@@ -19,11 +19,11 @@ class CancellationQueue
 
     public function enqueue($cancellable)
     {
-        if (!method_exists($cancellable, 'then') || !method_exists($cancellable, 'cancel')) {
+        if (!\method_exists($cancellable, 'then') || !\method_exists($cancellable, 'cancel')) {
             return;
         }
 
-        $length = array_push($this->queue, $cancellable);
+        $length = \array_push($this->queue, $cancellable);
 
         if ($this->started && 1 === $length) {
             $this->drain();

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -33,14 +33,14 @@ class Deferred implements PromisorInterface
     {
         $this->promise();
 
-        call_user_func($this->resolveCallback, $value);
+        \call_user_func($this->resolveCallback, $value);
     }
 
     public function reject($reason = null)
     {
         $this->promise();
 
-        call_user_func($this->rejectCallback, $reason);
+        \call_user_func($this->rejectCallback, $reason);
     }
 
     /**
@@ -51,7 +51,7 @@ class Deferred implements PromisorInterface
     {
         $this->promise();
 
-        call_user_func($this->notifyCallback, $update);
+        \call_user_func($this->notifyCallback, $update);
     }
 
     /**

--- a/src/LazyPromise.php
+++ b/src/LazyPromise.php
@@ -50,7 +50,7 @@ class LazyPromise implements ExtendedPromiseInterface, CancellablePromiseInterfa
     {
         if (null === $this->promise) {
             try {
-                $this->promise = resolve(call_user_func($this->factory));
+                $this->promise = resolve(\call_user_func($this->factory));
             } catch (\Throwable $exception) {
                 $this->promise = new RejectedPromise($exception);
             } catch (\Exception $exception) {

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -201,9 +201,9 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
         // function arguments is actually faster than blindly passing them.
         // Also, this helps avoiding unnecessary function arguments in the call stack
         // if the callback creates an Exception (creating garbage cycles).
-        if (is_array($callback)) {
+        if (\is_array($callback)) {
             $ref = new \ReflectionMethod($callback[0], $callback[1]);
-        } elseif (is_object($callback) && !$callback instanceof \Closure) {
+        } elseif (\is_object($callback) && !$callback instanceof \Closure) {
             $ref = new \ReflectionMethod($callback, '__invoke');
         } else {
             $ref = new \ReflectionFunction($callback);

--- a/src/UnhandledRejectionException.php
+++ b/src/UnhandledRejectionException.php
@@ -19,7 +19,7 @@ class UnhandledRejectionException extends \RuntimeException
     {
         $this->reason = $reason;
 
-        $message = sprintf('Unhandled Rejection: %s', json_encode($reason));
+        $message = \sprintf('Unhandled Rejection: %s', \json_encode($reason));
 
         parent::__construct($message, 0);
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -10,10 +10,10 @@ function resolve($promiseOrValue = null)
 
     // Check is_object() first to avoid method_exists() triggering
     // class autoloaders if $promiseOrValue is a string.
-    if (is_object($promiseOrValue) && method_exists($promiseOrValue, 'then')) {
+    if (\is_object($promiseOrValue) && \method_exists($promiseOrValue, 'then')) {
         $canceller = null;
 
-        if (method_exists($promiseOrValue, 'cancel')) {
+        if (\method_exists($promiseOrValue, 'cancel')) {
             $canceller = [$promiseOrValue, 'cancel'];
         }
 
@@ -70,7 +70,7 @@ function any($promisesOrValues)
 {
     return some($promisesOrValues, 1)
         ->then(function ($val) {
-            return array_shift($val);
+            return \array_shift($val);
         });
 }
 
@@ -82,16 +82,16 @@ function some($promisesOrValues, $howMany)
     return new Promise(function ($resolve, $reject, $notify) use ($promisesOrValues, $howMany, $cancellationQueue) {
         resolve($promisesOrValues)
             ->done(function ($array) use ($howMany, $cancellationQueue, $resolve, $reject, $notify) {
-                if (!is_array($array) || $howMany < 1) {
+                if (!\is_array($array) || $howMany < 1) {
                     $resolve([]);
                     return;
                 }
 
-                $len = count($array);
+                $len = \count($array);
 
                 if ($len < $howMany) {
                     throw new Exception\LengthException(
-                        sprintf(
+                        \sprintf(
                             'Input array must contain at least %d item%s but contains only %s item%s.',
                             $howMany,
                             1 === $howMany ? '' : 's',
@@ -148,12 +148,12 @@ function map($promisesOrValues, callable $mapFunc)
     return new Promise(function ($resolve, $reject, $notify) use ($promisesOrValues, $mapFunc, $cancellationQueue) {
         resolve($promisesOrValues)
             ->done(function ($array) use ($mapFunc, $cancellationQueue, $resolve, $reject, $notify) {
-                if (!is_array($array) || !$array) {
+                if (!\is_array($array) || !$array) {
                     $resolve([]);
                     return;
                 }
 
-                $toResolve = count($array);
+                $toResolve = \count($array);
                 $values    = [];
 
                 foreach ($array as $i => $promiseOrValue) {
@@ -186,11 +186,11 @@ function reduce($promisesOrValues, callable $reduceFunc, $initialValue = null)
     return new Promise(function ($resolve, $reject, $notify) use ($promisesOrValues, $reduceFunc, $initialValue, $cancellationQueue) {
         resolve($promisesOrValues)
             ->done(function ($array) use ($reduceFunc, $initialValue, $cancellationQueue, $resolve, $reject, $notify) {
-                if (!is_array($array)) {
+                if (!\is_array($array)) {
                     $array = [];
                 }
 
-                $total = count($array);
+                $total = \count($array);
                 $i = 0;
 
                 // Wrap the supplied $reduceFunc with one that handles promises and then
@@ -209,7 +209,7 @@ function reduce($promisesOrValues, callable $reduceFunc, $initialValue = null)
 
                 $cancellationQueue->enqueue($initialValue);
 
-                array_reduce($array, $wrappedReduceFunc, resolve($initialValue))
+                \array_reduce($array, $wrappedReduceFunc, resolve($initialValue))
                     ->done($resolve, $reject, $notify);
             }, $reject, $notify);
     }, $cancellationQueue);
@@ -218,13 +218,13 @@ function reduce($promisesOrValues, callable $reduceFunc, $initialValue = null)
 // Internal functions
 function _checkTypehint(callable $callback, $object)
 {
-    if (!is_object($object)) {
+    if (!\is_object($object)) {
         return true;
     }
 
-    if (is_array($callback)) {
+    if (\is_array($callback)) {
         $callbackReflection = new \ReflectionMethod($callback[0], $callback[1]);
-    } elseif (is_object($callback) && !$callback instanceof \Closure) {
+    } elseif (\is_object($callback) && !$callback instanceof \Closure) {
         $callbackReflection = new \ReflectionMethod($callback, '__invoke');
     } else {
         $callbackReflection = new \ReflectionFunction($callback);

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,5 +1,5 @@
 <?php
 
-if (!function_exists('React\Promise\resolve')) {
+if (!\function_exists('React\Promise\resolve')) {
     require __DIR__.'/functions.php';
 }


### PR DESCRIPTION
Just as previous PR's like https://github.com/reactphp/socket/pull/183 and https://github.com/reactphp/stream/pull/137 this prefixes all global functions and constants with a \ to gain a small performance boost