### PR TITLE
Improve performance by prefixing all global functions calls with \ to skip the look up and resolve process and go straight to the global function

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -33,13 +33,13 @@ final class Deferred implements PromisorInterface
     {
         $this->promise();
 
-        call_user_func($this->resolveCallback, $value);
+        \call_user_func($this->resolveCallback, $value);
     }
 
     public function reject($reason = null)
     {
         $this->promise();
 
-        call_user_func($this->rejectCallback, $reason);
+        \call_user_func($this->rejectCallback, $reason);
     }
 }

--- a/src/Internal/CancellationQueue.php
+++ b/src/Internal/CancellationQueue.php
@@ -22,11 +22,11 @@ final class CancellationQueue
 
     public function enqueue($cancellable)
     {
-        if (!method_exists($cancellable, 'then') || !method_exists($cancellable, 'cancel')) {
+        if (!\method_exists($cancellable, 'then') || !\method_exists($cancellable, 'cancel')) {
             return;
         }
 
-        $length = array_push($this->queue, $cancellable);
+        $length = \array_push($this->queue, $cancellable);
 
         if ($this->started && 1 === $length) {
             $this->drain();
@@ -35,7 +35,7 @@ final class CancellationQueue
 
     private function drain()
     {
-        for ($i = key($this->queue); isset($this->queue[$i]); $i++) {
+        for ($i = \key($this->queue); isset($this->queue[$i]); $i++) {
             $cancellable = $this->queue[$i];
 
             $exception = null;

--- a/src/Internal/Queue.php
+++ b/src/Internal/Queue.php
@@ -11,14 +11,14 @@ final class Queue
 
     public function enqueue(callable $task)
     {
-        if (1 === array_push($this->queue, $task)) {
+        if (1 === \array_push($this->queue, $task)) {
             $this->drain();
         }
     }
 
     private function drain()
     {
-        for ($i = key($this->queue); isset($this->queue[$i]); $i++) {
+        for ($i = \key($this->queue); isset($this->queue[$i]); $i++) {
             $task = $this->queue[$i];
 
             $exception = null;

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -181,9 +181,9 @@ final class Promise implements PromiseInterface
         // function arguments is actually faster than blindly passing them.
         // Also, this helps avoiding unnecessary function arguments in the call stack
         // if the callback creates an Exception (creating garbage cycles).
-        if (is_array($callback)) {
+        if (\is_array($callback)) {
             $ref = new \ReflectionMethod($callback[0], $callback[1]);
-        } elseif (is_object($callback) && !$callback instanceof \Closure) {
+        } elseif (\is_object($callback) && !$callback instanceof \Closure) {
             $ref = new \ReflectionMethod($callback, '__invoke');
         } else {
             $ref = new \ReflectionFunction($callback);

--- a/src/UnhandledRejectionException.php
+++ b/src/UnhandledRejectionException.php
@@ -19,7 +19,7 @@ class UnhandledRejectionException extends \RuntimeException
     {
         $this->reason = $reason;
 
-        $message = sprintf('Unhandled Rejection: %s', json_encode($reason));
+        $message = \sprintf('Unhandled Rejection: %s', \json_encode($reason));
 
         parent::__construct($message, 0);
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,10 +8,10 @@ function resolve($promiseOrValue = null)
         return $promiseOrValue;
     }
 
-    if (method_exists($promiseOrValue, 'then')) {
+    if (\method_exists($promiseOrValue, 'then')) {
         $canceller = null;
 
-        if (method_exists($promiseOrValue, 'cancel')) {
+        if (\method_exists($promiseOrValue, 'cancel')) {
             $canceller = [$promiseOrValue, 'cancel'];
         }
 
@@ -63,7 +63,7 @@ function any(array $promisesOrValues)
 {
     return some($promisesOrValues, 1)
         ->then(function ($val) {
-            return array_shift($val);
+            return \array_shift($val);
         });
 }
 
@@ -73,12 +73,12 @@ function some(array $promisesOrValues, $howMany)
         return resolve([]);
     }
 
-    $len = count($promisesOrValues);
+    $len = \count($promisesOrValues);
 
     if ($len < $howMany) {
         return reject(
             new Exception\LengthException(
-                sprintf(
+                \sprintf(
                     'Input array must contain at least %d item%s but contains only %s item%s.',
                     $howMany,
                     1 === $howMany ? '' : 's',
@@ -139,7 +139,7 @@ function map(array $promisesOrValues, callable $mapFunc)
     $cancellationQueue = new Internal\CancellationQueue();
 
     return new Promise(function ($resolve, $reject) use ($promisesOrValues, $mapFunc, $cancellationQueue) {
-        $toResolve = count($promisesOrValues);
+        $toResolve = \count($promisesOrValues);
         $values    = [];
 
         foreach ($promisesOrValues as $i => $promiseOrValue) {
@@ -167,7 +167,7 @@ function reduce(array $promisesOrValues, callable $reduceFunc, $initialValue = n
     $cancellationQueue = new Internal\CancellationQueue();
 
     return new Promise(function ($resolve, $reject) use ($promisesOrValues, $reduceFunc, $initialValue, $cancellationQueue) {
-        $total = count($promisesOrValues);
+        $total = \count($promisesOrValues);
         $i = 0;
 
         $wrappedReduceFunc = function ($current, $val) use ($reduceFunc, $cancellationQueue, $total, &$i) {
@@ -184,7 +184,7 @@ function reduce(array $promisesOrValues, callable $reduceFunc, $initialValue = n
 
         $cancellationQueue->enqueue($initialValue);
 
-        array_reduce($promisesOrValues, $wrappedReduceFunc, resolve($initialValue))
+        \array_reduce($promisesOrValues, $wrappedReduceFunc, resolve($initialValue))
             ->done($resolve, $reject);
     }, $cancellationQueue);
 }
@@ -209,13 +209,13 @@ function enqueue(callable $task)
 function fatalError($error)
 {
     try {
-        trigger_error($error, E_USER_ERROR);
+        \trigger_error($error, E_USER_ERROR);
     } catch (\Throwable $e) {
-        set_error_handler(null);
-        trigger_error($error, E_USER_ERROR);
+        \set_error_handler(null);
+        \trigger_error($error, E_USER_ERROR);
     } catch (\Exception $e) {
-        set_error_handler(null);
-        trigger_error($error, E_USER_ERROR);
+        \set_error_handler(null);
+        \trigger_error($error, E_USER_ERROR);
     }
 }
 
@@ -224,13 +224,13 @@ function fatalError($error)
  */
 function _checkTypehint(callable $callback, $object)
 {
-    if (!is_object($object)) {
+    if (!\is_object($object)) {
         return true;
     }
 
-    if (is_array($callback)) {
+    if (\is_array($callback)) {
         $callbackReflection = new \ReflectionMethod($callback[0], $callback[1]);
-    } elseif (is_object($callback) && !$callback instanceof \Closure) {
+    } elseif (\is_object($callback) && !$callback instanceof \Closure) {
         $callbackReflection = new \ReflectionMethod($callback, '__invoke');
     } else {
         $callbackReflection = new \ReflectionFunction($callback);

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,5 +1,5 @@
 <?php
 
-if (!function_exists('React\Promise\resolve')) {
+if (!\function_exists('React\Promise\resolve')) {
     require __DIR__.'/functions.php';
 }


### PR DESCRIPTION
Just as previous PR's like https://github.com/reactphp/promise/pull/133 and https://github.com/reactphp/socket/pull/183 and https://github.com/reactphp/stream/pull/137 this prefixes all global functions and constants with a \ to gain a small performance boost