### PR TITLE
Add PHPDoc in Promise::then method

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -25,6 +25,9 @@ class Promise implements ExtendedPromiseInterface, CancellablePromiseInterface
         $this->call($cb);
     }
 
+    /**
+     * @return static
+     */
     public function then(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null)
     {
         if (null !== $this->result) {


### PR DESCRIPTION
I'm using PHPStan to check my code.
When I'm using chaining method calls with `Promise->then(...)->otherwise(...)`, PHPStan is complaining about the fact that `otherwise` method is undefined in `PromiseInterface`.
I can break my chaining method calls and use the PHPDoc comment but it's not very sexy...
```
/** @var ExtendedPromiseInterface $promise */
$promise = $this->session->call(...)->then(...);
$promise->otherwise(...);
```

By adding the PHPDoc it fixes this warning and I can continue to use chaining method calls.