### PR TITLE
Add `then` method to ExtendedPromiseInterface

### DIFF
--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -35,7 +35,7 @@ interface PromiseInterface
      * @param callable|null $onFulfilled
      * @param callable|null $onRejected
      * @param callable|null $onProgress This argument is deprecated and should not be used anymore.
-     * @return PromiseInterface
+     * @return self
      */
     public function then(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null);
 }


### PR DESCRIPTION
Fixes return type for `then` method in ExtendedPromiseInterface