### PR TITLE
Enforce Throwable rejection reason and require PHP 7+ as a consequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly # ignore errors, see below
-  - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
 dist: trusty
 
 matrix:
   allow_failures:
-    - php: hhvm
     - php: nightly
 
 install:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A lightweight implementation of
 > For the code of the current stable 2.x release, checkout the 
 > [2.x branch](https://github.com/reactphp/promise/tree/2.x).
 
+> The upcoming 3.0 release will be the way forward for this package. 
+> However we will still actively support 2.0 and 1.0 for those not yet 
+> on PHP 7+.
+
 Table of Contents
 -----------------
 

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
         {"name": "Jan Sorgalla", "email": "jsorgalla@gmail.com"}
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4"
+        "phpunit/phpunit": "~6.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exception/CompositeException.php
+++ b/src/Exception/CompositeException.php
@@ -11,20 +11,20 @@ namespace React\Promise\Exception;
  */
 class CompositeException extends \Exception
 {
-    private $exceptions;
+    private $throwables;
 
-    public function __construct(array $exceptions, $message = '', $code = 0, $previous = null)
+    public function __construct(array $throwables, $message = '', $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
 
-        $this->exceptions = $exceptions;
+        $this->throwables = $throwables;
     }
 
     /**
-     * @return \Throwable[]|\Exception[]
+     * @return \Throwable[]
      */
-    public function getExceptions()
+    public function getThrowables()
     {
-        return $this->exceptions;
+        return $this->throwables;
     }
 }

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -27,8 +27,6 @@ final class FulfilledPromise implements PromiseInterface
                     $resolve($onFulfilled($this->value));
                 } catch (\Throwable $exception) {
                     $reject($exception);
-                } catch (\Exception $exception) {
-                    $reject($exception);
                 }
             });
         });
@@ -44,8 +42,6 @@ final class FulfilledPromise implements PromiseInterface
             try {
                 $result = $onFulfilled($this->value);
             } catch (\Throwable $exception) {
-                return fatalError($exception);
-            } catch (\Exception $exception) {
                 return fatalError($exception);
             }
 

--- a/src/Internal/CancellationQueue.php
+++ b/src/Internal/CancellationQueue.php
@@ -43,7 +43,6 @@ final class CancellationQueue
             try {
                 $cancellable->cancel();
             } catch (\Throwable $exception) {
-            } catch (\Exception $exception) {
             }
 
             unset($this->queue[$i]);

--- a/src/Internal/Queue.php
+++ b/src/Internal/Queue.php
@@ -26,7 +26,6 @@ final class Queue
             try {
                 $task();
             } catch (\Throwable $exception) {
-            } catch (\Exception $exception) {
             }
 
             unset($this->queue[$i]);

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -205,8 +205,6 @@ final class Promise implements PromiseInterface
             }
         } catch (\Throwable $e) {
             $this->reject($e);
-        } catch (\Exception $e) {
-            $this->reject($e);
         }
     }
 }

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -6,18 +6,8 @@ final class RejectedPromise implements PromiseInterface
 {
     private $reason;
 
-    public function __construct($reason)
+    public function __construct(\Throwable $reason)
     {
-        if (!$reason instanceof \Throwable && !$reason instanceof \Exception) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'A Promise must be rejected with a \Throwable or \Exception instance, got "%s" instead.',
-                    is_object($reason) ? get_class($reason) : gettype($reason)
-                )
-
-            );
-        }
-
         $this->reason = $reason;
     }
 
@@ -32,8 +22,6 @@ final class RejectedPromise implements PromiseInterface
                 try {
                     $resolve($onRejected($this->reason));
                 } catch (\Throwable $exception) {
-                    $reject($exception);
-                } catch (\Exception $exception) {
                     $reject($exception);
                 }
             });
@@ -50,8 +38,6 @@ final class RejectedPromise implements PromiseInterface
             try {
                 $result = $onRejected($this->reason);
             } catch (\Throwable $exception) {
-                return fatalError($exception);
-            } catch (\Exception $exception) {
                 return fatalError($exception);
             }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -53,10 +53,10 @@ function resolve($promiseOrValue = null)
  * throwing an exception. For example, it allows you to propagate a rejection with
  * the value of another promise.
  *
- * @param mixed $promiseOrValue
+ * @param \Throwable $promiseOrValue
  * @return PromiseInterface
  */
-function reject($reason)
+function reject(\Throwable $reason)
 {
     return new RejectedPromise($reason);
 }
@@ -316,9 +316,6 @@ function fatalError($error)
     try {
         \trigger_error($error, E_USER_ERROR);
     } catch (\Throwable $e) {
-        \set_error_handler(null);
-        \trigger_error($error, E_USER_ERROR);
-    } catch (\Exception $e) {
         \set_error_handler(null);
         \trigger_error($error, E_USER_ERROR);
     }

--- a/tests/FunctionRejectTest.php
+++ b/tests/FunctionRejectTest.php
@@ -18,13 +18,4 @@ class FunctionRejectTest extends TestCase
         reject($exception)
             ->then($this->expectCallableNever(), $mock);
     }
-
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
-    public function shouldThrowWhenCalledWithANonException()
-    {
-        reject(1);
-    }
 }

--- a/tests/FunctionalRejectTest.php
+++ b/tests/FunctionalRejectTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace React\Promise;
+
+use stdClass;
+
+class FunctionalRejectTest extends TestCase
+{
+    public function nonThrowables()
+    {
+        yield '1' => [1];
+        yield 'true' => [true];
+        yield 'stdClass' => [new stdClass()];
+    }
+
+    /**
+     * @test
+     * @dataProvider nonThrowables
+     */
+    public function shouldThrowWhenCalledWithANonException($input)
+    {
+        $errorCollector = new ErrorCollector();
+        $errorCollector->start();
+
+        (new Promise(function ($_, $reject) use ($input) {
+            $reject($input);
+        }))->done($this->expectCallableNever());
+
+        $errors = $errorCollector->stop();
+
+        $this->assertEquals(E_USER_ERROR, $errors[0]['errno']);
+        $this->assertContains(
+            'TypeError: Argument 1 passed to React\Promise\reject() must implement interface Throwable',
+            $errors[0]['errstr']
+        );
+    }
+}

--- a/tests/PromiseTest/RejectTestTrait.php
+++ b/tests/PromiseTest/RejectTestTrait.php
@@ -31,39 +31,6 @@ trait RejectTestTrait
         $adapter->reject($exception);
     }
 
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
-    public function rejectShouldThrowWhenCalledWithAnImmediateValue()
-    {
-        $adapter = $this->getPromiseTestAdapter();
-
-        $adapter->reject(1);
-    }
-
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
-    public function rejectShouldThrowWhenCalledWithAFulfilledPromise()
-    {
-        $adapter = $this->getPromiseTestAdapter();
-
-        $adapter->reject(Promise\resolve(1));
-    }
-
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
-    public function rejectShouldThrowWhenCalledWithARejectedPromise()
-    {
-        $adapter = $this->getPromiseTestAdapter();
-
-        $adapter->reject(Promise\reject(1));
-    }
-
     /** @test */
     public function rejectShouldForwardReasonWhenCallbackIsNull()
     {

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -40,13 +40,4 @@ class RejectedPromiseTest extends TestCase
             },
         ]);
     }
-
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
-    public function shouldThrowExceptionIfConstructedWithANonException()
-    {
-        return new RejectedPromise('foo');
-    }
 }


### PR DESCRIPTION
By enforcing `Throwable` as a rejection reason: 

- [x] Get rid of all the double checks for `Throwable` and `Exception` 
- [x] Can use typehints for it since we dropped direct `Exception` support (still supported through `Throwable`)
- [X] Bump to PHP 7.x+
- [x] Add note about support for older versions