### PR TITLE
Mark LazyPromise as deprecated for Promise v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ Note, that `$reason` **cannot** be a promise. It's recommended to use
 
 ### LazyPromise
 
+> Deprecated in v2.8.0: LazyPromise is deprecated and should not be used anymore.
+
 Creates a promise which will be lazily initialized by `$factory` once a consumer
 calls the `then()` method.
 

--- a/src/LazyPromise.php
+++ b/src/LazyPromise.php
@@ -2,6 +2,9 @@
 
 namespace React\Promise;
 
+/**
+ * @deprecated 2.8.0 LazyPromise is deprecated and should not be used anymore.
+ */
 class LazyPromise implements ExtendedPromiseInterface, CancellablePromiseInterface
 {
     private $factory;


### PR DESCRIPTION
Refs #98 which has been merged to remove `LazyPromise` in v3 altogether.