### PR TITLE
Improve documentation, add missing `new` keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ once all consumers called the `cancel()` method of the promise.
 Creates a already fulfilled promise.
 
 ```php
-$promise = React\Promise\FulfilledPromise($value);
+$promise = new React\Promise\FulfilledPromise($value);
 ```
 
 Note, that `$value` **cannot** be a promise. It's recommended to use
@@ -357,7 +357,7 @@ Note, that `$value` **cannot** be a promise. It's recommended to use
 Creates a already rejected promise.
 
 ```php
-$promise = React\Promise\RejectedPromise($reason);
+$promise = new React\Promise\RejectedPromise($reason);
 ```
 
 Note, that `$reason` **must** be a `\Throwable` or `\Exception`.


### PR DESCRIPTION
for React\Promise\FulfilledPromise and React\Promise\RejectedPromise
rif #27  fix #144