### PR TITLE
Port memory improvements from 2.x to master

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -15,7 +15,12 @@ final class Promise implements PromiseInterface
     {
         $this->canceller = $canceller;
 
-        $this->call($resolver);
+        // Explicitly overwrite arguments with null values before invoking
+        // resolver function. This ensure that these arguments do not show up
+        // in the stack trace in PHP 7+ only.
+        $cb = $resolver;
+        $resolver = $canceller = null;
+        $this->call($cb);
     }
 
     public function then(callable $onFulfilled = null, callable $onRejected = null): PromiseInterface

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -195,17 +195,68 @@ final class Promise implements PromiseInterface
             if ($args === 0) {
                 $callback();
             } else {
+                // keep a reference to this promise instance for the static resolve/reject functions.
+                // see also resolveFunction() and rejectFunction() for more details.
+                $target =& $this;
+
                 $callback(
-                    function ($value = null) {
-                        $this->resolve($value);
-                    },
-                    function (\Throwable $reason) {
-                        $this->reject($reason);
-                    }
+                    self::resolveFunction($target),
+                    self::rejectFunction($target)
                 );
             }
         } catch (\Throwable $e) {
+            $target = null;
             $this->reject($e);
         }
+    }
+
+    /**
+     * Creates a static resolver callback that is not bound to a promise instance.
+     *
+     * Moving the closure creation to a static method allows us to create a
+     * callback that is not bound to a promise instance. By passing the target
+     * promise instance by reference, we can still execute its resolving logic
+     * and still clear this reference when settling the promise. This helps
+     * avoiding garbage cycles if any callback creates an Exception.
+     *
+     * These assumptions are covered by the test suite, so if you ever feel like
+     * refactoring this, go ahead, any alternative suggestions are welcome!
+     *
+     * @param Promise $target
+     * @return callable
+     */
+    private static function resolveFunction(self &$target)
+    {
+        return function ($value = null) use (&$target) {
+            if ($target !== null) {
+                $target->settle(resolve($value));
+                $target = null;
+            }
+        };
+    }
+
+    /**
+     * Creates a static rejection callback that is not bound to a promise instance.
+     *
+     * Moving the closure creation to a static method allows us to create a
+     * callback that is not bound to a promise instance. By passing the target
+     * promise instance by reference, we can still execute its rejection logic
+     * and still clear this reference when settling the promise. This helps
+     * avoiding garbage cycles if any callback creates an Exception.
+     *
+     * These assumptions are covered by the test suite, so if you ever feel like
+     * refactoring this, go ahead, any alternative suggestions are welcome!
+     *
+     * @param Promise $target
+     * @return callable
+     */
+    private static function rejectFunction(self &$target)
+    {
+        return function ($reason = null) use (&$target) {
+            if ($target !== null) {
+                $target->reject($reason);
+                $target = null;
+            }
+        };
     }
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -14,6 +14,7 @@ final class Promise implements PromiseInterface
     public function __construct(callable $resolver, callable $canceller = null)
     {
         $this->canceller = $canceller;
+
         $this->call($resolver);
     }
 
@@ -174,8 +175,13 @@ final class Promise implements PromiseInterface
         return $promise;
     }
 
-    private function call(callable $callback): void
+    private function call(callable $cb): void
     {
+        // Explicitly overwrite argument with null value. This ensure that this
+        // argument does not show up in the stack trace in PHP 7+ only.
+        $callback = $cb;
+        $cb = null;
+
         // Use reflection to inspect number of arguments expected by this callback.
         // We did some careful benchmarking here: Using reflection to avoid unneeded
         // function arguments is actually faster than blindly passing them.

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -62,7 +62,7 @@ final class Promise implements PromiseInterface
             return;
         }
 
-        $this->handlers[] = function (PromiseInterface $promise) use ($onFulfilled, $onRejected) {
+        $this->handlers[] = static function (PromiseInterface $promise) use ($onFulfilled, $onRejected) {
             $promise
                 ->done($onFulfilled, $onRejected);
         };
@@ -70,7 +70,7 @@ final class Promise implements PromiseInterface
 
     public function otherwise(callable $onRejected): PromiseInterface
     {
-        return $this->then(null, function ($reason) use ($onRejected) {
+        return $this->then(null, static function ($reason) use ($onRejected) {
             if (!_checkTypehint($onRejected, $reason)) {
                 return new RejectedPromise($reason);
             }
@@ -81,11 +81,11 @@ final class Promise implements PromiseInterface
 
     public function always(callable $onFulfilledOrRejected): PromiseInterface
     {
-        return $this->then(function ($value) use ($onFulfilledOrRejected) {
+        return $this->then(static function ($value) use ($onFulfilledOrRejected) {
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
                 return $value;
             });
-        }, function ($reason) use ($onFulfilledOrRejected) {
+        }, static function ($reason) use ($onFulfilledOrRejected) {
             return resolve($onFulfilledOrRejected())->then(function () use ($reason) {
                 return new RejectedPromise($reason);
             });
@@ -130,7 +130,7 @@ final class Promise implements PromiseInterface
     private function resolver(callable $onFulfilled = null, callable $onRejected = null): callable
     {
         return function ($resolve, $reject) use ($onFulfilled, $onRejected) {
-            $this->handlers[] = function (PromiseInterface $promise) use ($onFulfilled, $onRejected, $resolve, $reject) {
+            $this->handlers[] = static function (PromiseInterface $promise) use ($onFulfilled, $onRejected, $resolve, $reject) {
                 $promise
                     ->then($onFulfilled, $onRejected)
                     ->done($resolve, $reject);

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -190,6 +190,72 @@ class PromiseTest extends TestCase
         $promise->cancel();
     }
 
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromise()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithThenFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->then()->then()->then();
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithDoneFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->done();
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithOtherwiseFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->otherwise(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithAlwaysFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->always(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithProgressFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->then(null, null, function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
     /** @test */
     public function shouldFulfillIfFullfilledWithSimplePromise()
     {

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -147,6 +147,24 @@ class PromiseTest extends TestCase
         $this->assertSame(0, gc_collect_cycles());
     }
 
+    /**
+     * @test
+     * @requires PHP 7
+     * @see self::shouldRejectWithoutCreatingGarbageCyclesIfCancellerWithReferenceThrowsException
+     */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfResolverWithReferenceThrowsException()
+    {
+        gc_collect_cycles();
+
+        $promise = new Promise(function () use (&$promise) {
+            throw new \Exception('foo');
+        });
+
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
     /** @test */
     public function shouldIgnoreNotifyAfterReject()
     {

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -137,7 +137,6 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerWithReferenceThrowsException()
     {
         gc_collect_cycles();
-
         $promise = new Promise(function () {}, function () use (&$promise) {
             throw new \Exception('foo');
         });
@@ -155,11 +154,25 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfResolverWithReferenceThrowsException()
     {
         gc_collect_cycles();
-
         $promise = new Promise(function () use (&$promise) {
             throw new \Exception('foo');
         });
+        unset($promise);
 
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /**
+     * @test
+     * @requires PHP 7
+     * @see self::shouldRejectWithoutCreatingGarbageCyclesIfCancellerWithReferenceThrowsException
+     */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerHoldsReferenceAndResolverThrowsException()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () {
+            throw new \Exception('foo');
+        }, function () use (&$promise) { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -121,6 +121,32 @@ class PromiseTest extends TestCase
         $this->assertSame(0, gc_collect_cycles());
     }
 
+    /**
+     * Test that checks number of garbage cycles after throwing from a canceller
+     * that explicitly uses a reference to the promise. This is rather synthetic,
+     * actual use cases often have implicit (hidden) references which ought not
+     * to be stored in the stack trace.
+     *
+     * Reassigned arguments only show up in the stack trace in PHP 7, so we can't
+     * avoid this on legacy PHP. As an alternative, consider explicitly unsetting
+     * any references before throwing.
+     *
+     * @test
+     * @requires PHP 7
+     */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerWithReferenceThrowsException()
+    {
+        gc_collect_cycles();
+
+        $promise = new Promise(function () {}, function () use (&$promise) {
+            throw new \Exception('foo');
+        });
+        $promise->cancel();
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
     /** @test */
     public function shouldIgnoreNotifyAfterReject()
     {

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -97,6 +97,19 @@ class PromiseTest extends TestCase
     }
 
     /** @test */
+    public function shouldRejectWithoutCreatingGarbageCyclesIfParentCancellerRejectsWithException()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function ($resolve, $reject) { }, function ($resolve, $reject) {
+            $reject(new \Exception('foo'));
+        });
+        $promise->then()->then()->then()->cancel();
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
     public function shouldRejectWithoutCreatingGarbageCyclesIfResolverThrowsException()
     {
         gc_collect_cycles();

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -52,6 +52,18 @@ class PromiseTest extends TestCase
     {
         gc_collect_cycles();
         $promise = new Promise(function () {
+            throw new \Exception('foo');
+        });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldFulfillIfFullfilledWithSimplePromise()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () {
             throw new Exception('foo');
         });
         unset($promise);


### PR DESCRIPTION
Cherry picked and ported the following PR commits targeting `2.x` into this PR to port the memory improvements from them into `3.x`: #113, #115, #116, #117, #118, #119, #123, #124