### PR TITLE
Drop call_user_func calls in favour of calling callables directly

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -33,13 +33,13 @@ final class Deferred implements PromisorInterface
     {
         $this->promise();
 
-        \call_user_func($this->resolveCallback, $value);
+        ($this->resolveCallback)($value);
     }
 
     public function reject(\Throwable $reason): void
     {
         $this->promise();
 
-        \call_user_func($this->rejectCallback, $reason);
+        ($this->rejectCallback)($reason);
     }
 }

--- a/tests/PromiseAdapter/CallbackPromiseAdapter.php
+++ b/tests/PromiseAdapter/CallbackPromiseAdapter.php
@@ -15,21 +15,21 @@ class CallbackPromiseAdapter implements PromiseAdapterInterface
 
     public function promise(): ?PromiseInterface
     {
-        return call_user_func_array($this->callbacks['promise'], func_get_args());
+        return ($this->callbacks['promise'])(...func_get_args());
     }
 
     public function resolve(): ?PromiseInterface
     {
-        return call_user_func_array($this->callbacks['resolve'], func_get_args());
+        return ($this->callbacks['resolve'])(...func_get_args());
     }
 
     public function reject(): ?PromiseInterface
     {
-        return call_user_func_array($this->callbacks['reject'], func_get_args());
+        return ($this->callbacks['reject'])(...func_get_args());
     }
 
     public function settle(): ?PromiseInterface
     {
-        return call_user_func_array($this->callbacks['settle'], func_get_args());
+        return ($this->callbacks['settle'])(...func_get_args());
     }
 }

--- a/tests/fixtures/SimpleTestCancellableThenable.php
+++ b/tests/fixtures/SimpleTestCancellableThenable.php
@@ -22,7 +22,7 @@ class SimpleTestCancellableThenable
         $this->cancelCalled = true;
 
         if (is_callable($this->onCancel)) {
-            call_user_func($this->onCancel);
+            ($this->onCancel)();
         }
     }
 }


### PR DESCRIPTION
With PHP 7 we can call callables directly rather then wrap it in a costly extra function call.