### PR TITLE
Narrow down docblock type of Deferred::promise

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -15,6 +15,9 @@ class Deferred implements PromisorInterface
         $this->canceller = $canceller;
     }
 
+    /**
+     * @return Promise
+     */
     public function promise()
     {
         if (null === $this->promise) {


### PR DESCRIPTION
The interface indicates it returns a `PromiseInterface`, but the implementation returns a `Promise`, which also implements `ExtendedPromiseInterface`.

Calling `Deferred::promise()` will make PHPStan complain if you need to return an `ExtendedPromiseInterface`, as it cannot deduce that it does indeed return it from the implementation alone.

This should also aid autocompletion in IDEs.