### PR TITLE
Added seq method.

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -295,6 +295,34 @@ function reduce(array $promisesOrValues, callable $reduceFunc, $initialValue = n
 }
 
 /**
+ * Sequential execution of given promises or values.
+ *
+ * @param array $promisesOrValues
+ *
+ * @return PromiseInterface
+ */
+function seq(array $promisesOrValues): PromiseInterface
+{
+    $promise = new FulfilledPromise();
+    $results = [];
+
+    foreach ($promisesOrValues as $promiseOrValue) {
+        $promise = $promise
+            ->then(function() use ($promiseOrValue) {
+                return $promiseOrValue;
+            })
+            ->then(function($result) use (&$results) {
+                $results[] = $result;
+            });
+    }
+
+    return $promise
+        ->then(function() use ($results) {
+            return $results;
+        });
+}
+
+/**
  * @internal
  */
 function enqueue(callable $task): void

--- a/tests/FunctionSeqTest.php
+++ b/tests/FunctionSeqTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace React\Promise;
+
+use Exception;
+
+class FunctionSeqTest extends TestCase
+{
+    /** @test */
+    public function shouldResolveOnlyOnce()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects(self::once())
+            ->method('__invoke');
+
+        seq([1, 2, 3])
+            ->then($mock);
+    }
+}


### PR DESCRIPTION
Executes each row of an array sequentially. Returns an array of each
result.

This PR is not tested yet.

```php
seq([
    $mysql->createTable(),
    $mysql->addElement(),
    $musql->findElement()
])
->then(array $results) {
    $result[2]->getId();
});
```