### PR TITLE
Suggestion: when detecting promisable by method presense check its an object

### DIFF
--- a/src/Internal/CancellationQueue.php
+++ b/src/Internal/CancellationQueue.php
@@ -22,7 +22,7 @@ final class CancellationQueue
 
     public function enqueue($cancellable): void
     {
-        if (!\method_exists($cancellable, 'then') || !\method_exists($cancellable, 'cancel')) {
+        if (!\is_object($cancellable) || !\method_exists($cancellable, 'then') || !\method_exists($cancellable, 'cancel')) {
             return;
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -25,7 +25,7 @@ function resolve($promiseOrValue = null): PromiseInterface
         return $promiseOrValue;
     }
 
-    if (\method_exists($promiseOrValue, 'then')) {
+    if (\is_object($promiseOrValue) && \method_exists($promiseOrValue, 'then')) {
         $canceller = null;
 
         if (\method_exists($promiseOrValue, 'cancel')) {


### PR DESCRIPTION
Currently, detecting thenable causes unwanted side effects #160