### PR TITLE
Test PHP 7.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
   - composer install
 
 script:
-  - ./vendor/bin/phpunit -v
   - ./vendor/bin/phpunit -v --coverage-text --coverage-clover=./build/logs/clover.xml
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - nightly # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
@@ -17,6 +18,7 @@ install:
   - composer install
 
 script:
+  - ./vendor/bin/phpunit -v
   - ./vendor/bin/phpunit -v --coverage-text --coverage-clover=./build/logs/clover.xml
 
 after_script:

--- a/tests/DeferredTest.php
+++ b/tests/DeferredTest.php
@@ -23,10 +23,6 @@ class DeferredTest extends TestCase
     /** @test */
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerRejectsWithException()
     {
-        if ($this->getTestResultObject()->getCollectCodeCoverageInformation() === true) {
-            $this->markTestSkipped('This test has memory leaks when code coverage is collected');
-        }
-
         gc_collect_cycles();
         $deferred = new Deferred(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
@@ -40,11 +36,9 @@ class DeferredTest extends TestCase
     /** @test */
     public function shouldRejectWithoutCreatingGarbageCyclesIfParentCancellerRejectsWithException()
     {
-        if ($this->getTestResultObject()->getCollectCodeCoverageInformation() === true) {
-            $this->markTestSkipped('This test has memory leaks when code coverage is collected');
-        }
-
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $deferred = new Deferred(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
         });
@@ -57,11 +51,9 @@ class DeferredTest extends TestCase
     /** @test */
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerHoldsReferenceAndExplicitlyRejectWithException()
     {
-        if ($this->getTestResultObject()->getCollectCodeCoverageInformation() === true) {
-            $this->markTestSkipped('This test has memory leaks when code coverage is collected');
-        }
-
         gc_collect_cycles();
+        gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
+
         $deferred = new Deferred(function () use (&$deferred) { });
         $deferred->reject(new \Exception('foo'));
         unset($deferred);

--- a/tests/DeferredTest.php
+++ b/tests/DeferredTest.php
@@ -23,6 +23,10 @@ class DeferredTest extends TestCase
     /** @test */
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerRejectsWithException()
     {
+        if ($this->getTestResultObject()->getCollectCodeCoverageInformation() === true) {
+            $this->markTestSkipped('This test has memory leaks when code coverage is collected');
+        }
+
         gc_collect_cycles();
         $deferred = new Deferred(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
@@ -36,6 +40,10 @@ class DeferredTest extends TestCase
     /** @test */
     public function shouldRejectWithoutCreatingGarbageCyclesIfParentCancellerRejectsWithException()
     {
+        if ($this->getTestResultObject()->getCollectCodeCoverageInformation() === true) {
+            $this->markTestSkipped('This test has memory leaks when code coverage is collected');
+        }
+
         gc_collect_cycles();
         $deferred = new Deferred(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
@@ -49,6 +57,10 @@ class DeferredTest extends TestCase
     /** @test */
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerHoldsReferenceAndExplicitlyRejectWithException()
     {
+        if ($this->getTestResultObject()->getCollectCodeCoverageInformation() === true) {
+            $this->markTestSkipped('This test has memory leaks when code coverage is collected');
+        }
+
         gc_collect_cycles();
         $deferred = new Deferred(function () use (&$deferred) { });
         $deferred->reject(new \Exception('foo'));


### PR DESCRIPTION
Builds on top of #157, thanks @WyriHaximus for the original version and helping tracking this down with @CharlotteDunois. This changeset builds on top of this, but instead of skipping affected tests will make sure tests pass by clearing any garbage references twice before running any of the affected assertions.

I still wonder if this could potentially be an upstream bug in `ext-xdebug` or PHP itself, but I don't see any guarantees that `gc_collect_cycles()` collects *all* cycles, so perhaps we were just *lucky* in previous versions. I consider this minimal changeset to be *good enough* until we find a better solution in the future :shipit: 