### PR TITLE
Mark `FulfilledPromise` and `RejectedPromise` as internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Table of Contents
      * [PromiseInterface::always()](#promiseinterfacealways)
      * [PromiseInterface::cancel()](#promiseinterfacecancel)
    * [Promise](#promise-2)
-   * [FulfilledPromise](#fulfilledpromise)
-   * [RejectedPromise](#rejectedpromise)
    * [Functions](#functions)
      * [resolve()](#resolve)
      * [reject()](#reject)
@@ -144,18 +142,14 @@ All consumers are notified by having `$onRejected` (which they registered via
 
 The promise interface provides the common interface for all promise
 implementations.
+See [Promise](#promise-2) for the only public implementation exposed by this
+package.
 
 A promise represents an eventual outcome, which is either fulfillment (success)
 and an associated value, or rejection (failure) and an associated reason.
 
 Once in the fulfilled or rejected state, a promise becomes immutable.
 Neither its state nor its result (or error) can be modified.
-
-#### Implementations
-
-* [Promise](#promise-2)
-* [FulfilledPromise](#fulfilledpromise)
-* [RejectedPromise](#rejectedpromise)
 
 #### PromiseInterface::then()
 
@@ -340,27 +334,6 @@ with that thrown exception as the rejection reason.
 
 The resolver function will be called immediately, the canceller function only
 once all consumers called the `cancel()` method of the promise.
-
-### FulfilledPromise
-
-Creates a already fulfilled promise.
-
-```php
-$promise = new React\Promise\FulfilledPromise($value);
-```
-
-Note, that `$value` **cannot** be a promise. It's recommended to use
-[resolve()](#resolve) for creating resolved promises.
-
-### RejectedPromise
-
-Creates a already rejected promise.
-
-```php
-$promise = new React\Promise\RejectedPromise($reason);
-```
-
-Note, that `$reason` **must** be a `\Throwable`.
 
 ### Functions
 

--- a/src/Internal/FulfilledPromise.php
+++ b/src/Internal/FulfilledPromise.php
@@ -1,7 +1,16 @@
 <?php
 
-namespace React\Promise;
+namespace React\Promise\Internal;
 
+use React\Promise\Promise;
+use React\Promise\PromiseInterface;
+use function React\Promise\enqueue;
+use function React\Promise\fatalError;
+use function React\Promise\resolve;
+
+/**
+ * @internal
+ */
 final class FulfilledPromise implements PromiseInterface
 {
     private $value;

--- a/src/Internal/RejectedPromise.php
+++ b/src/Internal/RejectedPromise.php
@@ -1,7 +1,17 @@
 <?php
 
-namespace React\Promise;
+namespace React\Promise\Internal;
 
+use React\Promise\Promise;
+use React\Promise\PromiseInterface;
+use function React\Promise\_checkTypehint;
+use function React\Promise\enqueue;
+use function React\Promise\fatalError;
+use function React\Promise\resolve;
+
+/**
+ * @internal
+ */
 final class RejectedPromise implements PromiseInterface
 {
     private $reason;

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -2,6 +2,8 @@
 
 namespace React\Promise;
 
+use React\Promise\Internal\RejectedPromise;
+
 final class Promise implements PromiseInterface
 {
     private $canceller;

--- a/src/functions.php
+++ b/src/functions.php
@@ -3,6 +3,8 @@
 namespace React\Promise;
 
 use React\Promise\Exception\CompositeException;
+use React\Promise\Internal\FulfilledPromise;
+use React\Promise\Internal\RejectedPromise;
 
 /**
  * Creates a promise for the supplied `$promiseOrValue`.

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -2,6 +2,8 @@
 
 namespace React\Promise;
 
+use React\Promise\Internal\FulfilledPromise;
+use React\Promise\Internal\RejectedPromise;
 use Exception;
 
 class FunctionResolveTest extends TestCase

--- a/tests/Internal/FulfilledPromiseTest.php
+++ b/tests/Internal/FulfilledPromiseTest.php
@@ -1,15 +1,18 @@
 <?php
 
-namespace React\Promise;
+namespace React\Promise\Internal;
 
 use InvalidArgumentException;
 use LogicException;
 use React\Promise\PromiseAdapter\CallbackPromiseAdapter;
+use React\Promise\PromiseTest\PromiseFulfilledTestTrait;
+use React\Promise\PromiseTest\PromiseSettledTestTrait;
+use React\Promise\TestCase;
 
 class FulfilledPromiseTest extends TestCase
 {
-    use PromiseTest\PromiseSettledTestTrait,
-        PromiseTest\PromiseFulfilledTestTrait;
+    use PromiseSettledTestTrait,
+        PromiseFulfilledTestTrait;
 
     public function getPromiseTestAdapter(callable $canceller = null)
     {

--- a/tests/Internal/RejectedPromiseTest.php
+++ b/tests/Internal/RejectedPromiseTest.php
@@ -1,15 +1,18 @@
 <?php
 
-namespace React\Promise;
+namespace React\Promise\Internal;
 
 use Exception;
 use LogicException;
 use React\Promise\PromiseAdapter\CallbackPromiseAdapter;
+use React\Promise\PromiseTest\PromiseRejectedTestTrait;
+use React\Promise\PromiseTest\PromiseSettledTestTrait;
+use React\Promise\TestCase;
 
 class RejectedPromiseTest extends TestCase
 {
-    use PromiseTest\PromiseSettledTestTrait,
-        PromiseTest\PromiseRejectedTestTrait;
+    use PromiseSettledTestTrait,
+        PromiseRejectedTestTrait;
 
     public function getPromiseTestAdapter(callable $canceller = null)
     {

--- a/tests/fixtures/SimpleFulfilledTestThenable.php
+++ b/tests/fixtures/SimpleFulfilledTestThenable.php
@@ -2,6 +2,8 @@
 
 namespace React\Promise;
 
+use React\Promise\Internal\RejectedPromise;
+
 class SimpleFulfilledTestThenable
 {
     public function then(callable $onFulfilled = null, callable $onRejected = null)


### PR DESCRIPTION
Use `resolve()` and `reject()` instead.

This PR introduces a BC break for the v3 Promise API by moving both classes to an internal namespace. A follow-up PR will deprecate both classes for the v2 Promise API. See #155 for more details.