### PR TITLE
Mark `FulfilledPromise` and `RejectedPromise` as deprecated (Promise v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ Neither its state nor its result (or error) can be modified.
 #### Implementations
 
 * [Promise](#promise-2)
-* [FulfilledPromise](#fulfilledpromise)
-* [RejectedPromise](#rejectedpromise)
-* [LazyPromise](#lazypromise)
+* [FulfilledPromise](#fulfilledpromise) (deprecated)
+* [RejectedPromise](#rejectedpromise) (deprecated)
+* [LazyPromise](#lazypromise) (deprecated)
 
 #### PromiseInterface::then()
 
@@ -225,9 +225,9 @@ and utility methods which are not part of the Promises/A specification.
 #### Implementations
 
 * [Promise](#promise-1)
-* [FulfilledPromise](#fulfilledpromise)
-* [RejectedPromise](#rejectedpromise)
-* [LazyPromise](#lazypromise)
+* [FulfilledPromise](#fulfilledpromise) (deprecated)
+* [RejectedPromise](#rejectedpromise) (deprecated)
+* [LazyPromise](#lazypromise) (deprecated)
 
 #### ExtendedPromiseInterface::done()
 
@@ -357,9 +357,9 @@ a promise has no effect.
 #### Implementations
 
 * [Promise](#promise-1)
-* [FulfilledPromise](#fulfilledpromise)
-* [RejectedPromise](#rejectedpromise)
-* [LazyPromise](#lazypromise)
+* [FulfilledPromise](#fulfilledpromise) (deprecated)
+* [RejectedPromise](#rejectedpromise) (deprecated)
+* [LazyPromise](#lazypromise) (deprecated)
 
 ### Promise
 
@@ -409,6 +409,8 @@ once all consumers called the `cancel()` method of the promise.
 
 ### FulfilledPromise
 
+> Deprecated in v2.8.0: External usage of `FulfilledPromise` is deprecated, use `resolve()` instead.
+
 Creates a already fulfilled promise.
 
 ```php
@@ -419,6 +421,8 @@ Note, that `$value` **cannot** be a promise. It's recommended to use
 [resolve()](#resolve) for creating resolved promises.
 
 ### RejectedPromise
+
+> Deprecated in v2.8.0: External usage of `RejectedPromise` is deprecated, use `reject()` instead.
 
 Creates a already rejected promise.
 

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -2,6 +2,9 @@
 
 namespace React\Promise;
 
+/**
+ * @deprecated 2.8.0 External usage of FulfilledPromise is deprecated, use `resolve()` instead.
+ */
 class FulfilledPromise implements ExtendedPromiseInterface, CancellablePromiseInterface
 {
     private $value;

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -2,6 +2,9 @@
 
 namespace React\Promise;
 
+/**
+ * @deprecated 2.8.0 External usage of RejectedPromise is deprecated, use `reject()` instead.
+ */
 class RejectedPromise implements ExtendedPromiseInterface, CancellablePromiseInterface
 {
     private $reason;


### PR DESCRIPTION
Use `resolve()` and `reject()` instead.

This marks both classes as deprecated in the Promise v2 API in order to safely remove them from our public API for the v3 Promise API (see #164). See #155 for more details.