### PR TITLE
Backport "Add check whether $cancellable is an object" to 2.x

### DIFF
--- a/src/CancellationQueue.php
+++ b/src/CancellationQueue.php
@@ -19,7 +19,7 @@ class CancellationQueue
 
     public function enqueue($cancellable)
     {
-        if (!\method_exists($cancellable, 'then') || !\method_exists($cancellable, 'cancel')) {
+        if (!\is_object($cancellable) || !\method_exists($cancellable, 'then') || !\method_exists($cancellable, 'cancel')) {
             return;
         }
 


### PR DESCRIPTION
This backports af072f6cd7ef6de5c82ad4ce881941b8e6209d2d from #161 to 2.x. Backporting the other commit 43edd6568ce1fe80ecf5bc06660b2aacd2bda15e isn't necessary as it was already addressed in #130.

This resolves https://github.com/reactphp/promise/pull/161#issuecomment-624581608