### PR TITLE
Add compose function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Table of Contents
      * [some()](#some)
      * [map()](#map)
      * [reduce()](#reduce)
+     * [compose()](#compose)
    * [PromisorInterface](#promisorinterface)
 4. [Examples](#examples)
    * [How to use Deferred](#how-to-use-deferred)
@@ -456,6 +457,17 @@ Traditional reduce function, similar to `array_reduce()`, but input may contain
 promises and/or values, and `$reduceFunc` may return either a value or a
 promise, *and* `$initialValue` may be a promise or a value for the starting
 value.
+
+#### compose()
+
+```php
+$promise = React\Promise\compose(callable ...$functions);
+```
+
+Uncommon compose function that chains functions each possessing an arity of 
+one and applicable on a value subsumed in a promise. It ultimately, upon 
+application on one promise object, evaluates to another promise object. 
+
 
 ### PromisorInterface
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -297,6 +297,35 @@ function reduce(array $promisesOrValues, callable $reduceFunc, $initialValue = n
 }
 
 /**
+ * Uncommon compose function chains functions applicable to the value
+ * subsumed in a promise. Composable functions possess an arity of 1.
+ * 
+ * @param callable $functions...
+ * @return PromiseInterface
+ */
+function compose(callable ...$functions)
+{
+    $identity = function ($val) {
+        return $val;
+    };
+
+
+    return \array_reduce($functions, function ($id, $function) {
+        return function ($promiseOrValue) use ($id, $function) {
+            return mapPromise($id, mapPromise($function, resolve($promiseOrValue)));
+        };
+    }, $identity);
+}
+
+/**
+ * @internal
+ */
+function mapPromise(callable $function, $promise)
+{
+    return $promise->then($function);
+}
+
+/**
  * @internal
  */
 function enqueue(callable $task): void

--- a/tests/FunctionComposeTest.php
+++ b/tests/FunctionComposeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace React\Promise;
+
+use Exception;
+
+class FunctionComposeTest extends TestCase
+{
+	/** @test  */
+	public function shouldChainFunctionsUsableOnPromise()
+	{
+		$val = resolve(2);
+		$mock = $this->createCallableMock();
+		$mock
+            ->expects(self::once())
+            ->method('__invoke')
+			->with(self::identicalTo(-1));
+			
+		compose(
+			fn ($x) => $x + 2,
+			fn ($x) => $x - 5
+		)($val)->then($mock);
+	}
+
+	/** @test  */
+	public function shouldChainFunctionsThatResultInPromiseUsableOnPromise()
+	{
+		$val = resolve(2);
+		$mock = $this->createCallableMock();
+		$mock
+            ->expects(self::once())
+            ->method('__invoke')
+			->with(self::identicalTo(-1));
+			
+		compose(
+			fn ($x) => resolve($x + 2),
+			fn ($x) => resolve($x - 5)
+		)($val)->then($mock);
+	}
+}


### PR DESCRIPTION
Chaining functions is endemic to writing code asynchronously, with promises. In this Pull Request is a simple primitive that allows for users of the library to effortlessly chain functions applicable on values subsumed in Promises.

A sequence like the one shown below presents an alternative to forward chaining with the `then()` method. 

```php
$operations = compose(
  fn ($x) => resolve($x ** 2),
  fn ($x) => $x - 5
);

$operations(resolve(2));
```