### PR TITLE
Trigger E_USER_ERROR on unhandled exceptions

### DIFF
--- a/src/Internal/FulfilledPromise.php
+++ b/src/Internal/FulfilledPromise.php
@@ -7,6 +7,7 @@ use React\Promise\PromiseInterface;
 use function React\Promise\enqueue;
 use function React\Promise\fatalError;
 use function React\Promise\resolve;
+use function React\Promise\unhandledException;
 
 /**
  * @internal
@@ -51,7 +52,7 @@ final class FulfilledPromise implements PromiseInterface
             try {
                 $result = $onFulfilled($this->value);
             } catch (\Throwable $exception) {
-                return fatalError($exception);
+                unhandledException($exception);
             }
 
             if ($result instanceof PromiseInterface) {

--- a/tests/DeferredTest.php
+++ b/tests/DeferredTest.php
@@ -27,6 +27,7 @@ class DeferredTest extends TestCase
         $deferred = new Deferred(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
         });
+        $deferred->promise()->then(null, function () { });
         $deferred->promise()->cancel();
         unset($deferred);
 
@@ -42,7 +43,7 @@ class DeferredTest extends TestCase
         $deferred = new Deferred(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
         });
-        $deferred->promise()->then()->cancel();
+        $deferred->promise()->then(null, function () { })->cancel();
         unset($deferred);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -56,6 +57,7 @@ class DeferredTest extends TestCase
 
         $deferred = new Deferred(function () use (&$deferred) { });
         $deferred->reject(new \Exception('foo'));
+        $deferred->promise()->then(null, function () { });
         unset($deferred);
 
         $this->assertSame(0, gc_collect_cycles());

--- a/tests/FunctionRaceTest.php
+++ b/tests/FunctionRaceTest.php
@@ -118,6 +118,6 @@ class FunctionRaceTest extends TestCase
 
         $promise2 = new Promise(function () {}, $this->expectCallableNever());
 
-        race([$deferred->promise(), $promise2])->cancel();
+        race([$deferred->promise(), $promise2])->then(null, function () { })->cancel();
     }
 }

--- a/tests/FunctionSomeTest.php
+++ b/tests/FunctionSomeTest.php
@@ -163,6 +163,8 @@ class FunctionSomeTest extends TestCase
 
         $promise2 = new Promise(function () {}, $this->expectCallableNever());
 
-        some([$deferred->promise(), $promise2], 2);
+        $ret = some([$deferred->promise(), $promise2], 2);
+
+        $ret->then(null, function () { });
     }
 }

--- a/tests/Internal/RejectedPromiseTest.php
+++ b/tests/Internal/RejectedPromiseTest.php
@@ -4,6 +4,7 @@ namespace React\Promise\Internal;
 
 use Exception;
 use LogicException;
+use React\Promise\ErrorCollector;
 use React\Promise\PromiseAdapter\CallbackPromiseAdapter;
 use React\Promise\PromiseTest\PromiseRejectedTestTrait;
 use React\Promise\PromiseTest\PromiseSettledTestTrait;
@@ -44,5 +45,15 @@ class RejectedPromiseTest extends TestCase
                 }
             },
         ]);
+    }
+
+    /** @test */
+    public function unhandledRejectionShouldTriggerFatalError()
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('foo');
+
+        $promise = new RejectedPromise(new Exception('foo'));
+        unset($promise);
     }
 }

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -66,6 +66,7 @@ class PromiseTest extends TestCase
         $promise = new Promise(function () {
             throw new \Exception('foo');
         });
+        $promise->then(null, function () { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -78,6 +79,7 @@ class PromiseTest extends TestCase
         $promise = new Promise(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
         });
+        $promise->then(null, function () { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -91,6 +93,7 @@ class PromiseTest extends TestCase
             $reject(new \Exception('foo'));
         });
         $promise->cancel();
+        $promise->then(null, function () { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -103,7 +106,7 @@ class PromiseTest extends TestCase
         $promise = new Promise(function ($resolve, $reject) { }, function ($resolve, $reject) {
             $reject(new \Exception('foo'));
         });
-        $promise->then()->then()->then()->cancel();
+        $promise->then()->then()->then(null, function () { })->cancel();
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -116,6 +119,7 @@ class PromiseTest extends TestCase
         $promise = new Promise(function ($resolve, $reject) {
             throw new \Exception('foo');
         });
+        $promise->then(null, function () { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -141,6 +145,7 @@ class PromiseTest extends TestCase
             throw new \Exception('foo');
         });
         $promise->cancel();
+        $promise->then(null, function () { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -157,6 +162,7 @@ class PromiseTest extends TestCase
         $promise = new Promise(function () use (&$promise) {
             throw new \Exception('foo');
         });
+        $promise->then(null, function () { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -173,6 +179,7 @@ class PromiseTest extends TestCase
         $promise = new Promise(function () {
             throw new \Exception('foo');
         }, function () use (&$promise) { });
+        $promise->then(null, function () { });
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -186,7 +193,7 @@ class PromiseTest extends TestCase
             $notify(42);
         });
 
-        $promise->then(null, null, $this->expectCallableNever());
+        $promise->then(null, function () { }, $this->expectCallableNever());
         $promise->cancel();
     }
 
@@ -263,6 +270,7 @@ class PromiseTest extends TestCase
         $promise = new Promise(function () {
             throw new Exception('foo');
         });
+        $promise->then(null, function () { });
         unset($promise);
 
         self::assertSame(0, gc_collect_cycles());

--- a/tests/PromiseTest/CancelTestTrait.php
+++ b/tests/PromiseTest/CancelTestTrait.php
@@ -105,15 +105,13 @@ trait CancelTestTrait
     /** @test */
     public function cancelShouldCallCancellerOnlyOnceIfCancellerResolves()
     {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->will($this->returnCallback(function ($resolve) {
-                $resolve();
-            }));
+        $once = $this->expectCallableOnce();
+        $canceller = function ($resolve) use ($once) {
+            $resolve();
+            $once();
+        };
 
-        $adapter = $this->getPromiseTestAdapter($mock);
+        $adapter = $this->getPromiseTestAdapter($canceller);
 
         $adapter->promise()->cancel();
         $adapter->promise()->cancel();

--- a/tests/PromiseTest/PromiseFulfilledTestTrait.php
+++ b/tests/PromiseTest/PromiseFulfilledTestTrait.php
@@ -227,17 +227,12 @@ trait PromiseFulfilledTestTrait
 
         $adapter->resolve(1);
 
-        $errorCollector = new ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         self::assertNull($adapter->promise()->done(function () {
             throw new Exception('Unhandled Rejection');
         }));
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
@@ -247,17 +242,12 @@ trait PromiseFulfilledTestTrait
 
         $adapter->resolve(1);
 
-        $errorCollector = new ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         self::assertNull($adapter->promise()->done(function () {
             return reject(new Exception('Unhandled Rejection'));
         }));
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */

--- a/tests/PromiseTest/PromiseRejectedTestTrait.php
+++ b/tests/PromiseTest/PromiseRejectedTestTrait.php
@@ -216,8 +216,8 @@ trait PromiseRejectedTestTrait
     /** @test */
     public function doneShouldTriggerFatalErrorExceptionThrownByRejectionHandlerForRejectedPromise()
     {
-        $errorCollector = new ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
@@ -225,18 +225,13 @@ trait PromiseRejectedTestTrait
         self::assertNull($adapter->promise()->done(null, function () {
             throw new Exception('Unhandled Rejection');
         }));
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorRejectionExceptionWhenRejectionHandlerRejectsWithExceptionForRejectedPromise()
     {
-        $errorCollector = new ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
@@ -244,37 +239,27 @@ trait PromiseRejectedTestTrait
         self::assertNull($adapter->promise()->done(null, function () {
             return reject(new Exception('Unhandled Rejection'));
         }));
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorExceptionProvidedAsRejectionValueForRejectedPromise()
     {
-        $errorCollector = new ErrorCollector();
-        $errorCollector->start();
-
         $adapter = $this->getPromiseTestAdapter();
 
         $exception = new Exception('Unhandled Rejection');
 
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
+
         $adapter->reject($exception);
         self::assertNull($adapter->promise()->done());
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertEquals((string) $exception, $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorWithDeepNestingPromiseChainsForRejectedPromise()
     {
-        $errorCollector = new ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('UnhandledRejectionException');
 
         $exception = new Exception('UnhandledRejectionException');
 
@@ -293,11 +278,6 @@ trait PromiseRejectedTestTrait
         })));
 
         $result->done();
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertEquals((string) $exception, $errors[0]['errstr']);
     }
 
     /** @test */
@@ -378,10 +358,13 @@ trait PromiseRejectedTestTrait
         $mock = $this->expectCallableNever();
 
         $adapter->reject($exception);
-        $adapter->promise()
+        $ret = $adapter->promise()
             ->otherwise(function (InvalidArgumentException $reason) use ($mock) {
                 $mock($reason);
             });
+
+        $ret->then(null, function () { });
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -497,6 +480,8 @@ trait PromiseRejectedTestTrait
         $adapter->reject(new Exception());
 
         self::assertNull($adapter->promise()->cancel());
+
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -507,5 +492,7 @@ trait PromiseRejectedTestTrait
         $adapter->reject(new Exception());
 
         $adapter->promise()->cancel();
+
+        $adapter->promise()->then(null, function () { });
     }
 }

--- a/tests/PromiseTest/PromiseSettledTestTrait.php
+++ b/tests/PromiseTest/PromiseSettledTestTrait.php
@@ -19,6 +19,8 @@ trait PromiseSettledTestTrait
 
         $adapter->settle();
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->then());
+
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -28,6 +30,8 @@ trait PromiseSettledTestTrait
 
         $adapter->settle();
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->then(null, null));
+
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -38,6 +42,8 @@ trait PromiseSettledTestTrait
         $adapter->settle();
 
         self::assertNull($adapter->promise()->cancel());
+
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -48,6 +54,8 @@ trait PromiseSettledTestTrait
         $adapter->settle();
 
         $adapter->promise()->cancel();
+
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -57,6 +65,8 @@ trait PromiseSettledTestTrait
 
         $adapter->settle();
         self::assertNull($adapter->promise()->done(null, function () {}));
+
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -66,6 +76,8 @@ trait PromiseSettledTestTrait
 
         $adapter->settle();
         self::assertNull($adapter->promise()->done(null, function () {}, null));
+
+        $adapter->promise()->then(null, function () { });
     }
 
     /** @test */
@@ -74,6 +86,8 @@ trait PromiseSettledTestTrait
         $adapter = $this->getPromiseTestAdapter();
 
         $adapter->settle();
-        self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->always(function () {}));
+        self::assertInstanceOf(PromiseInterface::class, $ret = $adapter->promise()->always(function () {}));
+
+        $ret->then(null, function () { });
     }
 }

--- a/tests/PromiseTest/RejectTestTrait.php
+++ b/tests/PromiseTest/RejectTestTrait.php
@@ -129,8 +129,8 @@ trait RejectTestTrait
     /** @test */
     public function doneShouldTriggerFatalErrorExceptionThrownByRejectionHandler()
     {
-        $errorCollector = new Promise\ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
@@ -138,18 +138,13 @@ trait RejectTestTrait
             throw new Exception('Unhandled Rejection');
         }));
         $adapter->reject(new Exception());
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorRejectionExceptionWhenRejectionHandlerRejectsWithException()
     {
-        $errorCollector = new Promise\ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
@@ -157,18 +152,13 @@ trait RejectTestTrait
             return reject(new Exception('Unhandled Rejection'));
         }));
         $adapter->reject(new Exception());
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorUnhandledRejectionExceptionWhenRejectionHandlerRetunsPendingPromiseWhichRejectsLater()
     {
-        $errorCollector = new Promise\ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
@@ -180,35 +170,25 @@ trait RejectTestTrait
         }));
         $adapter->reject(new Exception());
         $d->reject(new Exception('Unhandled Rejection'));
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorExceptionProvidedAsRejectionValue()
     {
-        $errorCollector = new Promise\ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
         self::assertNull($adapter->promise()->done());
         $adapter->reject(new Exception('Unhandled Rejection'));
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorWithDeepNestingPromiseChains()
     {
-        $errorCollector = new Promise\ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $exception = new Exception('Unhandled Rejection');
 
@@ -228,11 +208,6 @@ trait RejectTestTrait
         $result->done();
 
         $d->resolve();
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertEquals((string) $exception, $errors[0]['errstr']);
     }
 
     /** @test */

--- a/tests/PromiseTest/ResolveTestTrait.php
+++ b/tests/PromiseTest/ResolveTestTrait.php
@@ -187,8 +187,8 @@ trait ResolveTestTrait
     /** @test */
     public function doneShouldTriggerFatalErrorExceptionThrownFulfillmentHandler()
     {
-        $errorCollector = new Promise\ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
@@ -196,18 +196,13 @@ trait ResolveTestTrait
             throw new Exception('Unhandled Rejection');
         }));
         $adapter->resolve(1);
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */
     public function doneShouldTriggerFatalErrorUnhandledRejectionExceptionWhenFulfillmentHandlerRejects()
     {
-        $errorCollector = new Promise\ErrorCollector();
-        $errorCollector->start();
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Unhandled Rejection');
 
         $adapter = $this->getPromiseTestAdapter();
 
@@ -215,11 +210,6 @@ trait ResolveTestTrait
             return reject(new Exception('Unhandled Rejection'));
         }));
         $adapter->resolve(1);
-
-        $errors = $errorCollector->stop();
-
-        self::assertEquals(E_USER_ERROR, $errors[0]['errno']);
-        self::assertStringContainsString('Unhandled Rejection', $errors[0]['errstr']);
     }
 
     /** @test */

--- a/tests/UnHandledExceptionTest.php
+++ b/tests/UnHandledExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace React\Promise;
+
+use Exception;
+use React\Promise\Exception\CompositeException;
+use React\Promise\Exception\LengthException;
+
+class UnHandledExceptionTest extends TestCase
+{
+    /** @test */
+    public function handleRejectedException()
+    {
+        $cmd = \PHP_BINARY . ' ' . __DIR__ . DIRECTORY_SEPARATOR . 'child-processes' . DIRECTORY_SEPARATOR . 'handle-rejected-exception.php 2>&1';
+        $exitCode = null;
+        $output = array();
+
+        exec($cmd, $output, $exitCode);
+
+        self::assertSame(array(), $output);
+        self::assertSame(0, $exitCode);
+    }
+    /** @test */
+    public function unhandledRejectedException()
+    {
+        $cmd = \PHP_BINARY . ' ' . __DIR__ . DIRECTORY_SEPARATOR . 'child-processes' . DIRECTORY_SEPARATOR . 'unhandled-rejected-exception.php 2>&1';
+        $exitCode = null;
+        $output = array();
+
+        exec($cmd, $output, $exitCode);
+
+        self::assertStringContainsString('PHP Fatal error:  Uncaught Exception: Boom! in', implode(PHP_EOL, $output));
+        self::assertSame(255, $exitCode);
+    }
+}

--- a/tests/child-processes/handle-rejected-exception.php
+++ b/tests/child-processes/handle-rejected-exception.php
@@ -1,0 +1,11 @@
+<?php
+
+use function React\Promise\reject;
+
+require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+reject(new Exception('Boom!'))->then(null, static function () {
+    exit(0);
+});
+
+exit(2);

--- a/tests/child-processes/unhandled-rejected-exception.php
+++ b/tests/child-processes/unhandled-rejected-exception.php
@@ -1,0 +1,9 @@
+<?php
+
+use function React\Promise\reject;
+
+require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+reject(new Exception('Boom!'));
+
+exit(2);


### PR DESCRIPTION
Largely based on @clue's work at https://github.com/clue-labs/promise/commit/0feb517431633f6fc3da462cbea5c6bbba3d47d8 to trigger an error when a rejected promise hasn't been handled.

Closes #87