### PR TITLE
Initialize Deferred's state in the constructor

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -7,39 +7,27 @@ final class Deferred implements PromisorInterface
     private $promise;
     private $resolveCallback;
     private $rejectCallback;
-    private $canceller;
 
     public function __construct(callable $canceller = null)
     {
-        $this->canceller = $canceller;
+        $this->promise = new Promise(function ($resolve, $reject): void {
+            $this->resolveCallback = $resolve;
+            $this->rejectCallback  = $reject;
+        }, $canceller);
     }
 
     public function promise(): PromiseInterface
     {
-        if (null === $this->promise) {
-            $canceller = $this->canceller;
-            $this->canceller = null;
-
-            $this->promise = new Promise(function ($resolve, $reject): void {
-                $this->resolveCallback = $resolve;
-                $this->rejectCallback  = $reject;
-            }, $canceller);
-        }
-
         return $this->promise;
     }
 
     public function resolve($value = null): void
     {
-        $this->promise();
-
         ($this->resolveCallback)($value);
     }
 
     public function reject(\Throwable $reason): void
     {
-        $this->promise();
-
         ($this->rejectCallback)($reason);
     }
 }


### PR DESCRIPTION
This change

- refactors out unnecessary and hard-to-understand code from Deferred's methods,
- moves object state initialization where it belongs - to the constructor.

This is a self-contained and atomic change. All tests pass with PHP 7.3.9 on Windows 10 Pro (the latter shouldn't make a difference).
