### PR TITLE
Run tests on PHPUnit 9, simplify test matrix and clean up test suite (promise-2.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,21 @@
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
-  - nightly # ignore errors, see below
-  - hhvm # ignore errors, see below
-
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm-3.18
   allow_failures:
-    - php: hhvm
-    - php: nightly
+    - php: hhvm-3.18
 
 install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
->
+<phpunit bootstrap="vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="Promise Test Suite">
             <directory>./tests/</directory>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,7 +36,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
     public function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 10+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 9
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 
     public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)


### PR DESCRIPTION
* Updating and testing react/promise 2.x on PHPUnit 9
* For Reference look into #173 