### PR TITLE
Address deprecation of ReflectionType::getClass()

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory>./src/</directory>
-    </include>
-    <exclude>
-      <file>./src/functions_include.php</file>
-    </exclude>
-  </coverage>
-  <testsuites>
-    <testsuite name="Promise Test Suite">
-      <directory>./tests/</directory>
-    </testsuite>
-  </testsuites>
+
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Promise Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+            <exclude>
+                <file>./src/functions_include.php</file>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="Promise Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-            <exclude>
-                <file>./src/functions_include.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./src/</directory>
+    </include>
+    <exclude>
+      <file>./src/functions_include.php</file>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Promise Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/functions.php
+++ b/src/functions.php
@@ -342,7 +342,17 @@ function _checkTypehint(callable $callback, \Throwable $reason): bool
         return true;
     }
 
-    $expectedClass = $parameters[0]->getClass();
+    $expectedClass = null;
+    if (method_exists($parameters[0], 'getType')) {
+        $type = $parameters[0]->getType();
+        if (!$type || $type->isBuiltin()) {
+            return true;
+        }
+
+        $expectedClass = new \ReflectionClass(method_exists($type, 'getName') ? $type->getName() : (string) $type);
+    } else {
+        $expectedClass = $parameters[0]->getClass();
+    }
 
     if (!$expectedClass) {
         return true;

--- a/src/functions.php
+++ b/src/functions.php
@@ -350,7 +350,7 @@ function _checkTypehint(callable $callback, \Throwable $reason): bool
 
     $types = [$type];
 
-    if (\method_exists($type, 'getTypes')) {
+    if ($type instanceof \ReflectionUnionType) {
         $types = $type->getTypes();
     }
 
@@ -361,17 +361,13 @@ function _checkTypehint(callable $callback, \Throwable $reason): bool
             continue;
         }
 
-        try {
-            $expectedClass = new \ReflectionClass($type->getName());
+        $expectedClass = $type->getName();
 
-            if ($expectedClass->isInstance($reason)) {
-                return true;
-            } else {
-                $mismatched = true;
-            }
-        } catch (\ReflectionException $exception) {
-            $mismatched = true;
+        if ($reason instanceof $expectedClass) {
+            return true;
         }
+
+        $mismatched = true;
     }
 
     return !$mismatched;

--- a/src/functions.php
+++ b/src/functions.php
@@ -342,11 +342,33 @@ function _checkTypehint(callable $callback, \Throwable $reason): bool
         return true;
     }
 
-    $expectedClass = $parameters[0]->getClass();
+    $type = $parameters[0]->getType();
 
-    if (!$expectedClass) {
+    if (!$type) {
         return true;
     }
 
-    return $expectedClass->isInstance($reason);
+    $types = [$type];
+
+    if ($type instanceof \ReflectionUnionType) {
+        $types = $type->getTypes();
+    }
+
+    $mismatched = false;
+
+    foreach ($types as $type) {
+        if (!$type || $type->isBuiltin()) {
+            continue;
+        }
+
+        $expectedClass = $type->getName();
+
+        if ($reason instanceof $expectedClass) {
+            return true;
+        }
+
+        $mismatched = true;
+    }
+
+    return !$mismatched;
 }

--- a/tests/ErrorCollector.php
+++ b/tests/ErrorCollector.php
@@ -10,8 +10,8 @@ final class ErrorCollector
     {
         $errors = [];
 
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) use (&$errors) {
-            $errors[] = compact('errno', 'errstr', 'errfile', 'errline', 'errcontext');
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$errors) {
+            $errors[] = compact('errno', 'errstr', 'errfile', 'errline');
         });
 
         $this->errors = &$errors;

--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -17,29 +17,29 @@ class FunctionCheckTypehintTest extends TestCase
     /** @test */
     public function shouldAcceptFunctionStringCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithTypehintClass(), new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint(new TestCallbackWithTypehintClass(), new Exception()));
+        self::assertTrue(_checkTypehint(new CallbackWithTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new CallbackWithTypehintClass(), new Exception()));
     }
 
     /** @test */
     public function shouldAcceptInvokableObjectCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithTypehintClass(), new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint(new TestCallbackWithTypehintClass(), new Exception()));
+        self::assertTrue(_checkTypehint(new CallbackWithTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new CallbackWithTypehintClass(), new Exception()));
     }
 
     /** @test */
     public function shouldAcceptObjectMethodCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint([new TestCallbackWithTypehintClass(), 'testCallback'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([new TestCallbackWithTypehintClass(), 'testCallback'], new Exception()));
+        self::assertTrue(_checkTypehint([new CallbackWithTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([new CallbackWithTypehintClass(), 'testCallback'], new Exception()));
     }
 
     /** @test */
     public function shouldAcceptStaticClassCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint([TestCallbackWithTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([TestCallbackWithTypehintClass::class, 'testCallbackStatic'], new Exception()));
+        self::assertTrue(_checkTypehint([CallbackWithTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([CallbackWithTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
     /**
@@ -61,8 +61,8 @@ class FunctionCheckTypehintTest extends TestCase
      */
     public function shouldAcceptInvokableObjectCallbackWithUnionTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new Exception()));
+        self::assertTrue(_checkTypehint(new CallbackWithUnionTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new CallbackWithUnionTypehintClass(), new Exception()));
     }
 
     /**
@@ -71,8 +71,8 @@ class FunctionCheckTypehintTest extends TestCase
      */
     public function shouldAcceptObjectMethodCallbackWithUnionTypehint()
     {
-        self::assertTrue(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
+        self::assertTrue(_checkTypehint([new CallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([new CallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
     }
 
     /**
@@ -81,8 +81,8 @@ class FunctionCheckTypehintTest extends TestCase
      */
     public function shouldAcceptStaticClassCallbackWithUnionTypehint()
     {
-        self::assertTrue(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
+        self::assertTrue(_checkTypehint([CallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([CallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
     /** @test */
@@ -95,25 +95,25 @@ class FunctionCheckTypehintTest extends TestCase
     /** @test */
     public function shouldAcceptFunctionStringCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithoutTypehintClass(), new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint(new CallbackWithoutTypehintClass(), new InvalidArgumentException()));
     }
 
     /** @test */
     public function shouldAcceptInvokableObjectCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithoutTypehintClass(), new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint(new CallbackWithoutTypehintClass(), new InvalidArgumentException()));
     }
 
     /** @test */
     public function shouldAcceptObjectMethodCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint([new TestCallbackWithoutTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint([new CallbackWithoutTypehintClass(), 'testCallback'], new InvalidArgumentException()));
     }
 
     /** @test */
     public function shouldAcceptStaticClassCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint([TestCallbackWithoutTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint([CallbackWithoutTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
     }
 }
 
@@ -123,55 +123,4 @@ function testCallbackWithTypehint(InvalidArgumentException $e)
 
 function testCallbackWithoutTypehint()
 {
-}
-
-class TestCallbackWithTypehintClass
-{
-    public function __invoke(InvalidArgumentException $e)
-    {
-    }
-
-    public function testCallback(InvalidArgumentException $e)
-    {
-    }
-
-    public static function testCallbackStatic(InvalidArgumentException $e)
-    {
-    }
-}
-
-if (defined('PHP_MAJOR_VERSION') && (PHP_MAJOR_VERSION >= 8)) {
-    eval(<<<EOT
-namespace React\Promise;
-class TestCallbackWithUnionTypehintClass
-{
-    public function __invoke(\RuntimeException|\InvalidArgumentException \$e)
-    {
-    }
-
-    public function testCallback(\RuntimeException|\InvalidArgumentException \$e)
-    {
-    }
-
-    public static function testCallbackStatic(\RuntimeException|\InvalidArgumentException \$e)
-    {
-    }
-}
-EOT
-    );
-}
-
-class TestCallbackWithoutTypehintClass
-{
-    public function __invoke()
-    {
-    }
-
-    public function testCallback()
-    {
-    }
-
-    public static function testCallbackStatic()
-    {
-    }
 }

--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -42,6 +42,33 @@ class FunctionCheckTypehintTest extends TestCase
         self::assertFalse(_checkTypehint([TestCallbackWithTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
+    // Requires PHP 8
+    /*
+    public function shouldAcceptClosureCallbackWithUnionTypehint()
+    {
+        self::assertTrue(_checkTypehint(function (RuntimeException|InvalidArgumentException $e) {}, new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(function (RuntimeException|InvalidArgumentException $e) {}, new Exception()));
+    }
+
+    public function shouldAcceptInvokableObjectCallbackWithUnionTypehint()
+    {
+        self::assertTrue(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new Exception()));
+    }
+
+    public function shouldAcceptObjectMethodCallbackWithUnionTypehint()
+    {
+        self::assertTrue(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
+    }
+
+    public function shouldAcceptStaticClassCallbackWithUnionTypehint()
+    {
+        self::assertTrue(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
+    }
+    */
+
     /** @test */
     public function shouldAcceptClosureCallbackWithoutTypehint()
     {
@@ -52,7 +79,7 @@ class FunctionCheckTypehintTest extends TestCase
     /** @test */
     public function shouldAcceptFunctionStringCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithTypehintClass(), new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint(new TestCallbackWithoutTypehintClass(), new InvalidArgumentException()));
     }
 
     /** @test */
@@ -96,6 +123,24 @@ class TestCallbackWithTypehintClass
     {
     }
 }
+
+// Requires PHP 8
+/*
+class TestCallbackWithUnionTypehintClass
+{
+    public function __invoke(RuntimeException|InvalidArgumentException $e)
+    {
+    }
+
+    public function testCallback(RuntimeException|InvalidArgumentException $e)
+    {
+    }
+
+    public static function testCallbackStatic(RuntimeException|InvalidArgumentException $e)
+    {
+    }
+}
+*/
 
 class TestCallbackWithoutTypehintClass
 {

--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -5,6 +5,8 @@ namespace React\Promise;
 use Exception;
 use InvalidArgumentException;
 
+define('UNION_TYPE_TESTS_ENABLED', defined('PHP_MAJOR_VERSION') && (PHP_MAJOR_VERSION >= 8));
+
 class FunctionCheckTypehintTest extends TestCase
 {
     /** @test */
@@ -42,32 +44,52 @@ class FunctionCheckTypehintTest extends TestCase
         self::assertFalse(_checkTypehint([TestCallbackWithTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
-    // Requires PHP 8
-    /*
+    /** @test */
     public function shouldAcceptClosureCallbackWithUnionTypehint()
     {
-        self::assertTrue(_checkTypehint(function (RuntimeException|InvalidArgumentException $e) {}, new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint(function (RuntimeException|InvalidArgumentException $e) {}, new Exception()));
+        if (UNION_TYPE_TESTS_ENABLED) {
+            eval(
+                'namespace React\Promise;' .
+                'self::assertTrue(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \InvalidArgumentException()));' .
+                'self::assertFalse(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \Exception()));'
+            );
+        } else {
+            self::expectNotToPerformAssertions();
+        }
     }
 
+    /** @test */
     public function shouldAcceptInvokableObjectCallbackWithUnionTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new Exception()));
+        if (UNION_TYPE_TESTS_ENABLED) {
+            self::assertTrue(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new InvalidArgumentException()));
+            self::assertFalse(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new Exception()));
+        } else {
+            self::expectNotToPerformAssertions();
+        }
     }
 
+    /** @test */
     public function shouldAcceptObjectMethodCallbackWithUnionTypehint()
     {
-        self::assertTrue(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
+        if (UNION_TYPE_TESTS_ENABLED) {
+            self::assertTrue(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+            self::assertFalse(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
+        } else {
+            self::expectNotToPerformAssertions();
+        }
     }
 
+    /** @test */
     public function shouldAcceptStaticClassCallbackWithUnionTypehint()
     {
-        self::assertTrue(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
+        if (UNION_TYPE_TESTS_ENABLED) {
+            self::assertTrue(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+            self::assertFalse(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
+        } else {
+            self::expectNotToPerformAssertions();
+        }
     }
-    */
 
     /** @test */
     public function shouldAcceptClosureCallbackWithoutTypehint()
@@ -124,23 +146,26 @@ class TestCallbackWithTypehintClass
     }
 }
 
-// Requires PHP 8
-/*
+if (UNION_TYPE_TESTS_ENABLED) {
+    eval(<<<EOT
+namespace React\Promise;
 class TestCallbackWithUnionTypehintClass
 {
-    public function __invoke(RuntimeException|InvalidArgumentException $e)
+    public function __invoke(\RuntimeException|\InvalidArgumentException \$e)
     {
     }
 
-    public function testCallback(RuntimeException|InvalidArgumentException $e)
+    public function testCallback(\RuntimeException|\InvalidArgumentException \$e)
     {
     }
 
-    public static function testCallbackStatic(RuntimeException|InvalidArgumentException $e)
+    public static function testCallbackStatic(\RuntimeException|\InvalidArgumentException \$e)
     {
     }
 }
-*/
+EOT
+    );
+}
 
 class TestCallbackWithoutTypehintClass
 {

--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -5,8 +5,6 @@ namespace React\Promise;
 use Exception;
 use InvalidArgumentException;
 
-define('UNION_TYPE_TESTS_ENABLED', defined('PHP_MAJOR_VERSION') && (PHP_MAJOR_VERSION >= 8));
-
 class FunctionCheckTypehintTest extends TestCase
 {
     /** @test */
@@ -44,51 +42,47 @@ class FunctionCheckTypehintTest extends TestCase
         self::assertFalse(_checkTypehint([TestCallbackWithTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @requires PHP 8
+     */
     public function shouldAcceptClosureCallbackWithUnionTypehint()
     {
-        if (UNION_TYPE_TESTS_ENABLED) {
-            eval(
-                'namespace React\Promise;' .
-                'self::assertTrue(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \InvalidArgumentException()));' .
-                'self::assertFalse(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \Exception()));'
-            );
-        } else {
-            self::expectNotToPerformAssertions();
-        }
+        eval(
+            'namespace React\Promise;' .
+            'self::assertTrue(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \InvalidArgumentException()));' .
+            'self::assertFalse(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \Exception()));'
+        );
     }
 
-    /** @test */
+    /**
+     * @test
+     * @requires PHP 8
+     */
     public function shouldAcceptInvokableObjectCallbackWithUnionTypehint()
     {
-        if (UNION_TYPE_TESTS_ENABLED) {
-            self::assertTrue(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new InvalidArgumentException()));
-            self::assertFalse(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new Exception()));
-        } else {
-            self::expectNotToPerformAssertions();
-        }
+        self::assertTrue(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new TestCallbackWithUnionTypehintClass(), new Exception()));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @requires PHP 8
+     */
     public function shouldAcceptObjectMethodCallbackWithUnionTypehint()
     {
-        if (UNION_TYPE_TESTS_ENABLED) {
-            self::assertTrue(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
-            self::assertFalse(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
-        } else {
-            self::expectNotToPerformAssertions();
-        }
+        self::assertTrue(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([new TestCallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @requires PHP 8
+     */
     public function shouldAcceptStaticClassCallbackWithUnionTypehint()
     {
-        if (UNION_TYPE_TESTS_ENABLED) {
-            self::assertTrue(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
-            self::assertFalse(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
-        } else {
-            self::expectNotToPerformAssertions();
-        }
+        self::assertTrue(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([TestCallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
     /** @test */
@@ -146,7 +140,7 @@ class TestCallbackWithTypehintClass
     }
 }
 
-if (UNION_TYPE_TESTS_ENABLED) {
+if (defined('PHP_MAJOR_VERSION') && (PHP_MAJOR_VERSION >= 8)) {
     eval(<<<EOT
 namespace React\Promise;
 class TestCallbackWithUnionTypehintClass

--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -17,29 +17,72 @@ class FunctionCheckTypehintTest extends TestCase
     /** @test */
     public function shouldAcceptFunctionStringCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithTypehintClass(), new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint(new TestCallbackWithTypehintClass(), new Exception()));
+        self::assertTrue(_checkTypehint(new CallbackWithTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new CallbackWithTypehintClass(), new Exception()));
     }
 
     /** @test */
     public function shouldAcceptInvokableObjectCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithTypehintClass(), new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint(new TestCallbackWithTypehintClass(), new Exception()));
+        self::assertTrue(_checkTypehint(new CallbackWithTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new CallbackWithTypehintClass(), new Exception()));
     }
 
     /** @test */
     public function shouldAcceptObjectMethodCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint([new TestCallbackWithTypehintClass(), 'testCallback'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([new TestCallbackWithTypehintClass(), 'testCallback'], new Exception()));
+        self::assertTrue(_checkTypehint([new CallbackWithTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([new CallbackWithTypehintClass(), 'testCallback'], new Exception()));
     }
 
     /** @test */
     public function shouldAcceptStaticClassCallbackWithTypehint()
     {
-        self::assertTrue(_checkTypehint([TestCallbackWithTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
-        self::assertFalse(_checkTypehint([TestCallbackWithTypehintClass::class, 'testCallbackStatic'], new Exception()));
+        self::assertTrue(_checkTypehint([CallbackWithTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([CallbackWithTypehintClass::class, 'testCallbackStatic'], new Exception()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8
+     */
+    public function shouldAcceptClosureCallbackWithUnionTypehint()
+    {
+        eval(
+            'namespace React\Promise;' .
+            'self::assertTrue(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \InvalidArgumentException()));' .
+            'self::assertFalse(_checkTypehint(function (\RuntimeException|\InvalidArgumentException $e) {}, new \Exception()));'
+        );
+    }
+
+    /**
+     * @test
+     * @requires PHP 8
+     */
+    public function shouldAcceptInvokableObjectCallbackWithUnionTypehint()
+    {
+        self::assertTrue(_checkTypehint(new CallbackWithUnionTypehintClass(), new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint(new CallbackWithUnionTypehintClass(), new Exception()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8
+     */
+    public function shouldAcceptObjectMethodCallbackWithUnionTypehint()
+    {
+        self::assertTrue(_checkTypehint([new CallbackWithUnionTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([new CallbackWithUnionTypehintClass(), 'testCallback'], new Exception()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8
+     */
+    public function shouldAcceptStaticClassCallbackWithUnionTypehint()
+    {
+        self::assertTrue(_checkTypehint([CallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertFalse(_checkTypehint([CallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
     /** @test */
@@ -52,25 +95,25 @@ class FunctionCheckTypehintTest extends TestCase
     /** @test */
     public function shouldAcceptFunctionStringCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithTypehintClass(), new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint(new CallbackWithoutTypehintClass(), new InvalidArgumentException()));
     }
 
     /** @test */
     public function shouldAcceptInvokableObjectCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint(new TestCallbackWithoutTypehintClass(), new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint(new CallbackWithoutTypehintClass(), new InvalidArgumentException()));
     }
 
     /** @test */
     public function shouldAcceptObjectMethodCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint([new TestCallbackWithoutTypehintClass(), 'testCallback'], new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint([new CallbackWithoutTypehintClass(), 'testCallback'], new InvalidArgumentException()));
     }
 
     /** @test */
     public function shouldAcceptStaticClassCallbackWithoutTypehint()
     {
-        self::assertTrue(_checkTypehint([TestCallbackWithoutTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
+        self::assertTrue(_checkTypehint([CallbackWithoutTypehintClass::class, 'testCallbackStatic'], new InvalidArgumentException()));
     }
 }
 
@@ -80,34 +123,4 @@ function testCallbackWithTypehint(InvalidArgumentException $e)
 
 function testCallbackWithoutTypehint()
 {
-}
-
-class TestCallbackWithTypehintClass
-{
-    public function __invoke(InvalidArgumentException $e)
-    {
-    }
-
-    public function testCallback(InvalidArgumentException $e)
-    {
-    }
-
-    public static function testCallbackStatic(InvalidArgumentException $e)
-    {
-    }
-}
-
-class TestCallbackWithoutTypehintClass
-{
-    public function __invoke()
-    {
-    }
-
-    public function testCallback()
-    {
-    }
-
-    public static function testCallbackStatic()
-    {
-    }
 }

--- a/tests/fixtures/CallbackWithTypehintClass.php
+++ b/tests/fixtures/CallbackWithTypehintClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace React\Promise;
+
+use InvalidArgumentException;
+
+class CallbackWithTypehintClass
+{
+    public function __invoke(InvalidArgumentException $e)
+    {
+    }
+
+    public function testCallback(InvalidArgumentException $e)
+    {
+    }
+
+    public static function testCallbackStatic(InvalidArgumentException $e)
+    {
+    }
+}

--- a/tests/fixtures/CallbackWithUnionTypehintClass.php
+++ b/tests/fixtures/CallbackWithUnionTypehintClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace React\Promise;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+class CallbackWithUnionTypehintClass
+{
+    public function __invoke(RuntimeException|InvalidArgumentException $e)
+    {
+    }
+
+    public function testCallback(RuntimeException|InvalidArgumentException $e)
+    {
+    }
+
+    public static function testCallbackStatic(RuntimeException|InvalidArgumentException $e)
+    {
+    }
+}

--- a/tests/fixtures/CallbackWithoutTypehintClass.php
+++ b/tests/fixtures/CallbackWithoutTypehintClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace React\Promise;
+
+class CallbackWithoutTypehintClass
+{
+    public function __invoke()
+    {
+    }
+
+    public function testCallback()
+    {
+    }
+
+    public static function testCallbackStatic()
+    {
+    }
+}


### PR DESCRIPTION
Calling `ReflectionType::getClass()` will trigger a deprecation warning on PHP8. This PR switches to getType() if available.

```
Deprecated: Method ReflectionParameter::getClass() is deprecated in /app/vendor/react/promise/src/functions.php on line 345
```