### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and minor clean up

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 composer.lock
 composer.phar
-phpunit.xml
 build/
 vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ install:
   - composer install
 
 script:
-  - ./vendor/bin/phpunit -v --coverage-text --coverage-clover=./build/logs/clover.xml
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text --coverage-clover=./build/logs/clover.xml; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text --coverage-clover=./build/logs/clover.xml -c phpunit.xml.legacy; fi
 
 after_script:
   - if [ -f ./build/logs/clover.xml ]; then travis_retry composer require php-coveralls/php-coveralls --no-interaction --update-with-dependencies; fi

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^7.5"
+        "phpunit/phpunit": "^9.3 || ^7.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Promise Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-            <exclude>
-                <file>./src/functions_include.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <file>./src/functions_include.php</file>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Promise Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+            <exclude>
+                <file>./src/functions_include.php</file>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace React\Promise;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use React\Promise\Stub\CallableStub;
 
 class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).
This pull request builds on top of [reactphp/promise #175](https://github.com/reactphp/promise/pull/175).

Together with the changes from [reactphp/promise #176](https://github.com/reactphp/promise/pull/176) by @cdosoftei it's possible to run this code with PHP 8 🎉