### PR TITLE
Use full function namespaces to avoid clashes with serialization

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -84,11 +84,11 @@ final class Promise implements PromiseInterface
     public function always(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(static function ($value) use ($onFulfilledOrRejected) {
-            return resolve($onFulfilledOrRejected())->then(function () use ($value) {
+            return \React\Promise\resolve($onFulfilledOrRejected())->then(function () use ($value) {
                 return $value;
             });
         }, static function ($reason) use ($onFulfilledOrRejected) {
-            return resolve($onFulfilledOrRejected())->then(function () use ($reason) {
+            return \React\Promise\resolve($onFulfilledOrRejected())->then(function () use ($reason) {
                 return new RejectedPromise($reason);
             });
         });
@@ -146,7 +146,7 @@ final class Promise implements PromiseInterface
             return;
         }
 
-        $this->settle(reject($reason));
+        $this->settle(\React\Promise\reject($reason));
     }
 
     private function settle(PromiseInterface $result): void
@@ -223,7 +223,7 @@ final class Promise implements PromiseInterface
                 $callback(
                     static function ($value = null) use (&$target) {
                         if ($target !== null) {
-                            $target->settle(resolve($value));
+                            $target->settle(\React\Promise\resolve($value));
                             $target = null;
                         }
                     },


### PR DESCRIPTION
`Promise.php` contains function calls (`resolve` and `reject` from `src/functions.php`) that expect the current namespace. However if you serialize & then later unserialize a Promise, this namespace is lost, and the function calls clash with other defined global functions.

E.g. if using Laravel, you serialize a `\React\Promise\Promise` instance, and then later unserialize & attempt to resolve it - the call to `resolve` on line 232 clashes with Laravel's global `resolve` function - causing it to throw an exception as it runs through the global Laravel function.

By using the full namespace on the function call this eliminates this possible problem. Also makes the code an easier read IMO making it obvious that these are namespaced (and not global) functions.