### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and run tests on PHPUnit 9 (promise-2.x)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
   - composer install
 
 script:
-  - ./vendor/bin/phpunit -v --coverage-text --coverage-clover=./build/logs/clover.xml
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text --coverage-clover=./build/logs/clover.xml; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy --coverage-clover=./build/logs/clover.xml; fi
 
 after_script:
   - if [ -f ./build/logs/clover.xml ]; then travis_retry composer require satooshi/php-coveralls --no-interaction --update-with-dependencies; fi

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true"
-         cacheResult="false">
+         colors="true">
     <testsuites>
         <testsuite name="Promise Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
+    <filter>
+        <whitelist>
             <directory>./src/</directory>
             <exclude>
                 <file>./src/functions_include.php</file>
             </exclude>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/PromiseTest/NotifyTestTrait.php
+++ b/tests/PromiseTest/NotifyTestTrait.php
@@ -235,14 +235,10 @@ trait NotifyTestTrait
         $adapter = $this->getPromiseTestAdapter();
 
         $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->at(0))
-            ->method('__invoke')
-            ->with($this->identicalTo(1));
-        $mock
-            ->expects($this->at(1))
-            ->method('__invoke')
-            ->with($this->identicalTo(2));
+        $mock->expects($this->exactly(2))->method('__invoke')->withConsecutive(
+            array($this->identicalTo(1)),
+            array($this->identicalTo(2))
+        );
 
         $adapter->promise()
             ->then(
@@ -261,14 +257,10 @@ trait NotifyTestTrait
         $adapter = $this->getPromiseTestAdapter();
 
         $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->at(0))
-            ->method('__invoke')
-            ->with($this->identicalTo(1));
-        $mock
-            ->expects($this->at(1))
-            ->method('__invoke')
-            ->with($this->identicalTo(2));
+        $mock->expects($this->exactly(2))->method('__invoke')->withConsecutive(
+            array($this->identicalTo(1)),
+            array($this->identicalTo(2))
+        );
 
         $adapter->promise()
             ->then(


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file because the new format is unknown for them.
For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).

This pull request builds on top of #174 and #177.