### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and run tests on PHPUnit 9 (promise-1.x)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": { 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Promise Test Suite">
             <directory>./tests/React/Promise/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Promise Test Suite">
+            <directory>./tests/React/Promise/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/React/Promise/DeferredProgressTest.php
+++ b/tests/React/Promise/DeferredProgressTest.php
@@ -259,14 +259,10 @@ class DeferredProgressTest extends TestCase
         $d = new Deferred();
 
         $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->at(0))
-            ->method('__invoke')
-            ->with($this->identicalTo(1));
-        $mock
-            ->expects($this->at(1))
-            ->method('__invoke')
-            ->with($this->identicalTo(2));
+        $mock->expects($this->exactly(2))->method('__invoke')->withConsecutive(
+            array($this->identicalTo(1)),
+            array($this->identicalTo(2))
+        );
 
         $d
             ->promise()
@@ -290,14 +286,10 @@ class DeferredProgressTest extends TestCase
         $d = new Deferred();
 
         $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->at(0))
-            ->method('__invoke')
-            ->with($this->identicalTo(1));
-        $mock
-            ->expects($this->at(1))
-            ->method('__invoke')
-            ->with($this->identicalTo(2));
+        $mock->expects($this->exactly(2))->method('__invoke')->withConsecutive(
+            array($this->identicalTo(1)),
+            array($this->identicalTo(2))
+        );
 
         $d
             ->promise()


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file because the new format is unknown for them.
For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).

This pull request builds on top of #175 and #177.