### PR TITLE
Reduced promises depth test

### DIFF
--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -130,12 +130,12 @@ class FunctionResolveTest extends TestCase
     {
         $deferreds = [];
 
-        for ($i = 0; $i < 250; $i++) {
+        for ($i = 0; $i < 150; $i++) {
             $deferreds[] = $d = new Deferred();
             $p = $d->promise();
 
             $last = $p;
-            for ($j = 0; $j < 250; $j++) {
+            for ($j = 0; $j < 150; $j++) {
                 $last = $last->then(function ($result) {
                     return $result;
                 });


### PR DESCRIPTION
When I execute phpunit, it prompts me `Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes)`, which I know I can fix by modifying php.ini. I think I can reduce the promises depth, i.e. I can not modify the memory_limit (default 128M) and also ensure the correct test, thanks. (very sorry, English is not my native language)