### PR TITLE
Support intersection types (PHP 8.1+ / Promise v2)

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -341,43 +341,49 @@ function _checkTypehint(callable $callback, $object)
         return true;
     }
 
-    if (\PHP_VERSION_ID < 70100 || \defined('HHVM_VERSION')) {
-        $expectedException = $parameters[0];
+    $expectedException = $parameters[0];
 
+    // PHP before v8 used an easy API:
+    if (\PHP_VERSION_ID < 70100 || \defined('HHVM_VERSION')) {
         if (!$expectedException->getClass()) {
             return true;
         }
 
         return $expectedException->getClass()->isInstance($object);
-    } else {
-        $type = $parameters[0]->getType();
+    }
 
-        if (!$type) {
+    // Extract the type of the argument and handle different possibilities
+    $type = $expectedException->getType();
+    $types = [];
+
+    switch (true) {
+        case $type === null:
+            break;
+        case $type instanceof \ReflectionNamedType:
+            $types = [$type];
+            break;
+        case $type instanceof \ReflectionUnionType;
+            $types = $type->getTypes();
+            break;
+        default:
+            throw new \LogicException('Unexpected return value of ReflectionParameter::getType');
+    }
+
+    // If there is no type restriction, it matches
+    if (empty($types)) {
+        return true;
+    }
+
+    // Search for one matching named-type for success, otherwise return false
+    // A named-type can be either a class-name or a built-in type like string, int, array, etc.
+    foreach ($types as $type) {
+        $matches = ($type->isBuiltin() && \gettype($object) === $type->getName())
+            || (new \ReflectionClass($type->getName()))->isInstance($object);
+
+        if ($matches) {
             return true;
         }
-
-        $types = [$type];
-
-        if ($type instanceof \ReflectionUnionType) {
-            $types = $type->getTypes();
-        }
-
-        $mismatched = false;
-
-        foreach ($types as $type) {
-            if (!$type || $type->isBuiltin()) {
-                continue;
-            }
-
-            $expectedClass = $type->getName();
-
-            if ($object instanceof $expectedClass) {
-                return true;
-            }
-
-            $mismatched = true;
-        }
-
-        return !$mismatched;
     }
+
+    return false;
 }

--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -84,6 +84,39 @@ class FunctionCheckTypehintTest extends TestCase
         self::assertFalse(_checkTypehint(['React\Promise\CallbackWithUnionTypehintClass', 'testCallbackStatic'], new \Exception()));
     }
 
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function shouldAcceptInvokableObjectCallbackWithIntersectionTypehint()
+    {
+        self::assertFalse(_checkTypehint(new CallbackWithIntersectionTypehintClass(), new \RuntimeException()));
+        self::assertFalse(_checkTypehint(new CallbackWithIntersectionTypehintClass(), new CountableNonException()));
+        self::assertTrue(_checkTypehint(new CallbackWithIntersectionTypehintClass(), new CountableException()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function shouldAcceptObjectMethodCallbackWithIntersectionTypehint()
+    {
+        self::assertFalse(_checkTypehint([new CallbackWithIntersectionTypehintClass(), 'testCallback'], new \RuntimeException()));
+        self::assertFalse(_checkTypehint([new CallbackWithIntersectionTypehintClass(), 'testCallback'], new CountableNonException()));
+        self::assertTrue(_checkTypehint([new CallbackWithIntersectionTypehintClass(), 'testCallback'], new CountableException()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function shouldAcceptStaticClassCallbackWithIntersectionTypehint()
+    {
+        self::assertFalse(_checkTypehint(['React\Promise\CallbackWithIntersectionTypehintClass', 'testCallbackStatic'], new \RuntimeException()));
+        self::assertFalse(_checkTypehint(['React\Promise\CallbackWithIntersectionTypehintClass', 'testCallbackStatic'], new CountableNonException()));
+        self::assertTrue(_checkTypehint(['React\Promise\CallbackWithIntersectionTypehintClass', 'testCallbackStatic'], new CountableException()));
+    }
+
     /** @test */
     public function shouldAcceptClosureCallbackWithoutTypehint()
     {

--- a/tests/fixtures/CallbackWithIntersectionTypehintClass.php
+++ b/tests/fixtures/CallbackWithIntersectionTypehintClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace React\Promise;
+
+use Countable;
+use RuntimeException;
+
+class CallbackWithIntersectionTypehintClass
+{
+    public function __invoke(RuntimeException&Countable $e)
+    {
+    }
+
+    public function testCallback(RuntimeException&Countable $e)
+    {
+    }
+
+    public static function testCallbackStatic(RuntimeException&Countable $e)
+    {
+    }
+}

--- a/tests/fixtures/CountableException.php
+++ b/tests/fixtures/CountableException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\Promise;
+
+use Countable;
+use RuntimeException;
+
+class CountableException extends RuntimeException implements Countable
+{
+    public function count()
+    {
+        return 0;
+    }
+}
+

--- a/tests/fixtures/CountableNonException.php
+++ b/tests/fixtures/CountableNonException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\Promise;
+
+use Countable;
+use RuntimeException;
+
+class CountableNonException implements Countable
+{
+    public function count()
+    {
+        return 0;
+    }
+}
+


### PR DESCRIPTION
PHP8's reflection API changed to make room for handling of union-types. As one of the consequences `ReflectionParameter::getClass` got marked as deprecated.
This commit moves the legacy path behind a version-check for PHP versions before 8 and adds a new more complex path for PHP8+.

Fixes #192.