### PR TITLE
Support PHP 8.1 (Promise v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3


### PR DESCRIPTION
Added upcoming PHP 8.1 version to the test matrix. Builds on top of #186.

See also #199 for same changes for Promise v3