### PR TITLE
Fix `include` section in `phpunit.xml.dist` to avoid warning (Promise v2)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,9 @@
     <coverage>
         <include>
             <directory>./src/</directory>
-            <exclude>
-                <file>./src/functions_include.php</file>
-            </exclude>
         </include>
+        <exclude>
+            <file>./src/functions_include.php</file>
+        </exclude>
     </coverage>
 </phpunit>


### PR DESCRIPTION
Just noticed a warning in #200, this one fixes it.