### PR TITLE
ExtendedPromiseInterface: type-hint for then()

### DIFF
--- a/src/ExtendedPromiseInterface.php
+++ b/src/ExtendedPromiseInterface.php
@@ -2,6 +2,9 @@
 
 namespace React\Promise;
 
+/**
+ * @method ExtendedPromiseInterface then(callable $onFulfilled = null, callable $onRejected = null, callable $onProgress = null)
+ */
 interface ExtendedPromiseInterface extends PromiseInterface
 {
     /**


### PR DESCRIPTION
This solves the problem that a PHP IDE always believes your then()
method returns a PromiseInterface and not an ExtendedPromiseInterface