### PR TITLE
Add branch-alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,10 @@
     "keywords": [
         "promise",
         "promises"
-    ]
+    ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This allows requiring the package as `^3@dev` which is safer than `dev-master` in the long run.