### PR TITLE
Add `catch()` and `finally()`, deprecate `otherwise()` and `always()`

### DIFF
--- a/src/Internal/FulfilledPromise.php
+++ b/src/Internal/FulfilledPromise.php
@@ -60,12 +60,12 @@ final class FulfilledPromise implements PromiseInterface
         });
     }
 
-    public function otherwise(callable $onRejected): PromiseInterface
+    public function catch(callable $onRejected): PromiseInterface
     {
         return $this;
     }
 
-    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    public function finally(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(function ($value) use ($onFulfilledOrRejected): PromiseInterface {
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
@@ -76,5 +76,23 @@ final class FulfilledPromise implements PromiseInterface
 
     public function cancel(): void
     {
+    }
+
+    /**
+     * @deprecated 3.0.0 Use `catch()` instead
+     * @see self::catch()
+     */
+    public function otherwise(callable $onRejected): PromiseInterface
+    {
+        return $this->catch($onRejected);
+    }
+
+    /**
+     * @deprecated 3.0.0 Use `finally()` instead
+     * @see self::finally()
+     */
+    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    {
+        return $this->finally($onFulfilledOrRejected);
     }
 }

--- a/src/Internal/RejectedPromise.php
+++ b/src/Internal/RejectedPromise.php
@@ -61,7 +61,7 @@ final class RejectedPromise implements PromiseInterface
         });
     }
 
-    public function otherwise(callable $onRejected): PromiseInterface
+    public function catch(callable $onRejected): PromiseInterface
     {
         if (!_checkTypehint($onRejected, $this->reason)) {
             return $this;
@@ -70,7 +70,7 @@ final class RejectedPromise implements PromiseInterface
         return $this->then(null, $onRejected);
     }
 
-    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    public function finally(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(null, function (\Throwable $reason) use ($onFulfilledOrRejected): PromiseInterface {
             return resolve($onFulfilledOrRejected())->then(function () use ($reason): PromiseInterface {
@@ -81,5 +81,23 @@ final class RejectedPromise implements PromiseInterface
 
     public function cancel(): void
     {
+    }
+
+    /**
+     * @deprecated 3.0.0 Use `catch()` instead
+     * @see self::catch()
+     */
+    public function otherwise(callable $onRejected): PromiseInterface
+    {
+        return $this->catch($onRejected);
+    }
+
+    /**
+     * @deprecated 3.0.0 Use `always()` instead
+     * @see self::always()
+     */
+    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    {
+        return $this->finally($onFulfilledOrRejected);
     }
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -70,7 +70,7 @@ final class Promise implements PromiseInterface
         };
     }
 
-    public function otherwise(callable $onRejected): PromiseInterface
+    public function catch(callable $onRejected): PromiseInterface
     {
         return $this->then(null, static function ($reason) use ($onRejected) {
             if (!_checkTypehint($onRejected, $reason)) {
@@ -81,7 +81,7 @@ final class Promise implements PromiseInterface
         });
     }
 
-    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    public function finally(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(static function ($value) use ($onFulfilledOrRejected) {
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
@@ -127,6 +127,24 @@ final class Promise implements PromiseInterface
         if ($parentCanceller) {
             $parentCanceller();
         }
+    }
+
+    /**
+     * @deprecated 3.0.0 Use `catch()` instead
+     * @see self::catch()
+     */
+    public function otherwise(callable $onRejected): PromiseInterface
+    {
+        return $this->catch($onRejected);
+    }
+
+    /**
+     * @deprecated 3.0.0 Use `finally()` instead
+     * @see self::finally()
+     */
+    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    {
+        return $this->finally($onFulfilledOrRejected);
     }
 
     private function resolver(callable $onFulfilled = null, callable $onRejected = null): callable

--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -63,7 +63,7 @@ interface PromiseInterface
      * @param callable $onRejected
      * @return PromiseInterface
      */
-    public function otherwise(callable $onRejected): PromiseInterface;
+    public function catch(callable $onRejected): PromiseInterface;
 
     /**
      * Allows you to execute "cleanup" type tasks in a promise chain.
@@ -82,8 +82,8 @@ interface PromiseInterface
      *    rejected promise, `$newPromise` will reject with the thrown exception or
      *    rejected promise's reason.
      *
-     * `always()` behaves similarly to the synchronous finally statement. When combined
-     * with `otherwise()`, `always()` allows you to write code that is similar to the familiar
+     * `finally()` behaves similarly to the synchronous finally statement. When combined
+     * with `catch()`, `finally()` allows you to write code that is similar to the familiar
      * synchronous catch/finally pair.
      *
      * Consider the following synchronous code:
@@ -103,14 +103,14 @@ interface PromiseInterface
      *
      * ```php
      * return doSomething()
-     *     ->otherwise('handleError')
-     *     ->always('cleanup');
+     *     ->catch('handleError')
+     *     ->finally('cleanup');
      * ```
      *
      * @param callable $onFulfilledOrRejected
      * @return PromiseInterface
      */
-    public function always(callable $onFulfilledOrRejected): PromiseInterface;
+    public function finally(callable $onFulfilledOrRejected): PromiseInterface;
 
     /**
      * The `cancel()` method notifies the creator of the promise that there is no
@@ -122,4 +122,38 @@ interface PromiseInterface
      * @return void
      */
     public function cancel(): void;
+
+    /**
+     * [Deprecated] Registers a rejection handler for a promise.
+     *
+     * This method continues to exist only for BC reasons and to ease upgrading
+     * between versions. It is an alias for:
+     *
+     * ```php
+     * $promise->catch($onRejected);
+     * ```
+     *
+     * @param callable $onRejected
+     * @return PromiseInterface
+     * @deprecated 3.0.0 Use catch() instead
+     * @see self::catch()
+     */
+    public function otherwise(callable $onRejected): PromiseInterface;
+
+    /**
+     * [Deprecated] Allows you to execute "cleanup" type tasks in a promise chain.
+     *
+     * This method continues to exist only for BC reasons and to ease upgrading
+     * between versions. It is an alias for:
+     *
+     * ```php
+     * $promise->finally($onFulfilledOrRejected);
+     * ```
+     *
+     * @param callable $onFulfilledOrRejected
+     * @return PromiseInterface
+     * @deprecated 3.0.0 Use finally() instead
+     * @see self::finally()
+     */
+    public function always(callable $onFulfilledOrRejected): PromiseInterface;
 }

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -224,6 +224,31 @@ class PromiseTest extends TestCase
     }
 
     /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithCatchFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->catch(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /** @test */
+    public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithFinallyFollowers()
+    {
+        gc_collect_cycles();
+        $promise = new Promise(function () { });
+        $promise->finally(function () { });
+        unset($promise);
+
+        $this->assertSame(0, gc_collect_cycles());
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
     public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithOtherwiseFollowers()
     {
         gc_collect_cycles();
@@ -234,7 +259,10 @@ class PromiseTest extends TestCase
         $this->assertSame(0, gc_collect_cycles());
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     public function shouldNotLeaveGarbageCyclesWhenRemovingLastReferenceToPendingPromiseWithAlwaysFollowers()
     {
         gc_collect_cycles();

--- a/tests/PromiseTest/PromiseFulfilledTestTrait.php
+++ b/tests/PromiseTest/PromiseFulfilledTestTrait.php
@@ -261,6 +261,121 @@ trait PromiseFulfilledTestTrait
     }
 
     /** @test */
+    public function catchShouldNotInvokeRejectionHandlerForFulfilledPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $adapter->resolve(1);
+        $adapter->promise()->catch($this->expectCallableNever());
+    }
+
+    /** @test */
+    public function finallyShouldNotSuppressValueForFulfilledPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $value = new stdClass();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($value));
+
+        $adapter->resolve($value);
+        $adapter->promise()
+            ->finally(function () {})
+            ->then($mock);
+    }
+
+    /** @test */
+    public function finallyShouldNotSuppressValueWhenHandlerReturnsANonPromiseForFulfilledPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $value = new stdClass();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($value));
+
+        $adapter->resolve($value);
+        $adapter->promise()
+            ->finally(function () {
+                return 1;
+            })
+            ->then($mock);
+    }
+
+    /** @test */
+    public function finallyShouldNotSuppressValueWhenHandlerReturnsAPromiseForFulfilledPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $value = new stdClass();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($value));
+
+        $adapter->resolve($value);
+        $adapter->promise()
+            ->finally(function () {
+                return resolve(1);
+            })
+            ->then($mock);
+    }
+
+    /** @test */
+    public function finallyShouldRejectWhenHandlerThrowsForFulfilledPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception));
+
+        $adapter->resolve(1);
+        $adapter->promise()
+            ->finally(function () use ($exception) {
+                throw $exception;
+            })
+            ->then(null, $mock);
+    }
+
+    /** @test */
+    public function finallyShouldRejectWhenHandlerRejectsForFulfilledPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception));
+
+        $adapter->resolve(1);
+        $adapter->promise()
+            ->finally(function () use ($exception) {
+                return reject($exception);
+            })
+            ->then(null, $mock);
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
     public function otherwiseShouldNotInvokeRejectionHandlerForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
@@ -269,7 +384,10 @@ trait PromiseFulfilledTestTrait
         $adapter->promise()->otherwise($this->expectCallableNever());
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     public function alwaysShouldNotSuppressValueForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
@@ -288,7 +406,10 @@ trait PromiseFulfilledTestTrait
             ->then($mock);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     public function alwaysShouldNotSuppressValueWhenHandlerReturnsANonPromiseForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
@@ -309,7 +430,10 @@ trait PromiseFulfilledTestTrait
             ->then($mock);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     public function alwaysShouldNotSuppressValueWhenHandlerReturnsAPromiseForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
@@ -330,7 +454,10 @@ trait PromiseFulfilledTestTrait
             ->then($mock);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     public function alwaysShouldRejectWhenHandlerThrowsForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
@@ -351,7 +478,10 @@ trait PromiseFulfilledTestTrait
             ->then(null, $mock);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     public function alwaysShouldRejectWhenHandlerRejectsForFulfilledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();

--- a/tests/PromiseTest/PromisePendingTestTrait.php
+++ b/tests/PromiseTest/PromisePendingTestTrait.php
@@ -53,6 +53,26 @@ trait PromisePendingTestTrait
     }
 
     /** @test */
+    public function catchShouldNotInvokeRejectionHandlerForPendingPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $adapter->settle();
+        $adapter->promise()->catch($this->expectCallableNever());
+    }
+
+    /** @test */
+    public function finallyShouldReturnAPromiseForPendingPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->finally(function () {}));
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
     public function otherwiseShouldNotInvokeRejectionHandlerForPendingPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
@@ -61,7 +81,10 @@ trait PromisePendingTestTrait
         $adapter->promise()->otherwise($this->expectCallableNever());
     }
 
-    /** @test */
+    /**
+     * @test
+     * @deprecated
+     */
     public function alwaysShouldReturnAPromiseForPendingPromise()
     {
         $adapter = $this->getPromiseTestAdapter();

--- a/tests/PromiseTest/PromiseRejectedTestTrait.php
+++ b/tests/PromiseTest/PromiseRejectedTestTrait.php
@@ -312,7 +312,7 @@ trait PromiseRejectedTestTrait
     }
 
     /** @test */
-    public function otherwiseShouldInvokeRejectionHandlerForRejectedPromise()
+    public function catchShouldInvokeRejectionHandlerForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -325,11 +325,11 @@ trait PromiseRejectedTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->reject($exception);
-        $adapter->promise()->otherwise($mock);
+        $adapter->promise()->catch($mock);
     }
 
     /** @test */
-    public function otherwiseShouldInvokeNonTypeHintedRejectionHandlerIfReasonIsAnExceptionForRejectedPromise()
+    public function catchShouldInvokeNonTypeHintedRejectionHandlerIfReasonIsAnExceptionForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -343,13 +343,13 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->otherwise(function ($reason) use ($mock) {
+            ->catch(function ($reason) use ($mock) {
                 $mock($reason);
             });
     }
 
     /** @test */
-    public function otherwiseShouldInvokeRejectionHandlerIfReasonMatchesTypehintForRejectedPromise()
+    public function catchShouldInvokeRejectionHandlerIfReasonMatchesTypehintForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -363,13 +363,13 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->otherwise(function (InvalidArgumentException $reason) use ($mock) {
+            ->catch(function (InvalidArgumentException $reason) use ($mock) {
                 $mock($reason);
             });
     }
 
     /** @test */
-    public function otherwiseShouldNotInvokeRejectionHandlerIfReaonsDoesNotMatchTypehintForRejectedPromise()
+    public function catchShouldNotInvokeRejectionHandlerIfReaonsDoesNotMatchTypehintForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -379,13 +379,13 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->otherwise(function (InvalidArgumentException $reason) use ($mock) {
+            ->catch(function (InvalidArgumentException $reason) use ($mock) {
                 $mock($reason);
             });
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressRejectionForRejectedPromise()
+    public function finallyShouldNotSuppressRejectionForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -399,12 +399,12 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->always(function () {})
+            ->finally(function () {})
             ->then(null, $mock);
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressRejectionWhenHandlerReturnsANonPromiseForRejectedPromise()
+    public function finallyShouldNotSuppressRejectionWhenHandlerReturnsANonPromiseForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -418,14 +418,14 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->always(function () {
+            ->finally(function () {
                 return 1;
             })
             ->then(null, $mock);
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressRejectionWhenHandlerReturnsAPromiseForRejectedPromise()
+    public function finallyShouldNotSuppressRejectionWhenHandlerReturnsAPromiseForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -439,14 +439,14 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->always(function () {
+            ->finally(function () {
                 return resolve(1);
             })
             ->then(null, $mock);
     }
 
     /** @test */
-    public function alwaysShouldRejectWhenHandlerThrowsForRejectedPromise()
+    public function finallyShouldRejectWhenHandlerThrowsForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -461,14 +461,14 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception1);
         $adapter->promise()
-            ->always(function () use ($exception2) {
+            ->finally(function () use ($exception2) {
                 throw $exception2;
             })
             ->then(null, $mock);
     }
 
     /** @test */
-    public function alwaysShouldRejectWhenHandlerRejectsForRejectedPromise()
+    public function finallyShouldRejectWhenHandlerRejectsForRejectedPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -483,7 +483,7 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception1);
         $adapter->promise()
-            ->always(function () use ($exception2) {
+            ->finally(function () use ($exception2) {
                 return reject($exception2);
             })
             ->then(null, $mock);
@@ -507,5 +507,210 @@ trait PromiseRejectedTestTrait
         $adapter->reject(new Exception());
 
         $adapter->promise()->cancel();
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function otherwiseShouldInvokeRejectionHandlerForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception));
+
+        $adapter->reject($exception);
+        $adapter->promise()->otherwise($mock);
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function otherwiseShouldInvokeNonTypeHintedRejectionHandlerIfReasonIsAnExceptionForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception));
+
+        $adapter->reject($exception);
+        $adapter->promise()
+            ->otherwise(function ($reason) use ($mock) {
+                $mock($reason);
+            });
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function otherwiseShouldInvokeRejectionHandlerIfReasonMatchesTypehintForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new InvalidArgumentException();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception));
+
+        $adapter->reject($exception);
+        $adapter->promise()
+            ->otherwise(function (InvalidArgumentException $reason) use ($mock) {
+                $mock($reason);
+            });
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function otherwiseShouldNotInvokeRejectionHandlerIfReaonsDoesNotMatchTypehintForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->expectCallableNever();
+
+        $adapter->reject($exception);
+        $adapter->promise()
+            ->otherwise(function (InvalidArgumentException $reason) use ($mock) {
+                $mock($reason);
+            });
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function alwaysShouldNotSuppressRejectionForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception));
+
+        $adapter->reject($exception);
+        $adapter->promise()
+            ->always(function () {})
+            ->then(null, $mock);
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function alwaysShouldNotSuppressRejectionWhenHandlerReturnsANonPromiseForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+        ->expects($this->once())
+        ->method('__invoke')
+        ->with($this->identicalTo($exception));
+
+        $adapter->reject($exception);
+        $adapter->promise()
+        ->finally(function () {
+            return 1;
+        })
+        ->then(null, $mock);
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function alwaysShouldNotSuppressRejectionWhenHandlerReturnsAPromiseForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception));
+
+        $adapter->reject($exception);
+        $adapter->promise()
+            ->always(function () {
+                return resolve(1);
+            })
+            ->then(null, $mock);
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function alwaysShouldRejectWhenHandlerThrowsForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception1 = new Exception();
+        $exception2 = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception2));
+
+        $adapter->reject($exception1);
+        $adapter->promise()
+            ->always(function () use ($exception2) {
+                throw $exception2;
+            })
+            ->then(null, $mock);
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
+    public function alwaysShouldRejectWhenHandlerRejectsForRejectedPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $exception1 = new Exception();
+        $exception2 = new Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($exception2));
+
+        $adapter->reject($exception1);
+        $adapter->promise()
+            ->always(function () use ($exception2) {
+                return reject($exception2);
+            })
+            ->then(null, $mock);
     }
 }

--- a/tests/PromiseTest/PromiseSettledTestTrait.php
+++ b/tests/PromiseTest/PromiseSettledTestTrait.php
@@ -69,6 +69,18 @@ trait PromiseSettledTestTrait
     }
 
     /** @test */
+    public function finallyShouldReturnAPromiseForSettledPromise()
+    {
+        $adapter = $this->getPromiseTestAdapter();
+
+        $adapter->settle();
+        self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->finally(function () {}));
+    }
+
+    /**
+     * @test
+     * @deprecated
+     */
     public function alwaysShouldReturnAPromiseForSettledPromise()
     {
         $adapter = $this->getPromiseTestAdapter();

--- a/tests/PromiseTest/RejectTestTrait.php
+++ b/tests/PromiseTest/RejectTestTrait.php
@@ -91,7 +91,7 @@ trait RejectTestTrait
     }
 
     /** @test */
-    public function rejectShouldInvokeOtherwiseHandler()
+    public function rejectShouldInvokeCatchHandler()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -104,7 +104,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->otherwise($mock);
+            ->catch($mock);
 
         $adapter->reject($exception);
     }
@@ -247,7 +247,7 @@ trait RejectTestTrait
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressRejection()
+    public function finallyShouldNotSuppressRejection()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -260,14 +260,14 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->always(function () {})
+            ->finally(function () {})
             ->then(null, $mock);
 
         $adapter->reject($exception);
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressRejectionWhenHandlerReturnsANonPromise()
+    public function finallyShouldNotSuppressRejectionWhenHandlerReturnsANonPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -280,7 +280,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->always(function () {
+            ->finally(function () {
                 return 1;
             })
             ->then(null, $mock);
@@ -289,7 +289,7 @@ trait RejectTestTrait
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressRejectionWhenHandlerReturnsAPromise()
+    public function finallyShouldNotSuppressRejectionWhenHandlerReturnsAPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -302,7 +302,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->always(function () {
+            ->finally(function () {
                 return resolve(1);
             })
             ->then(null, $mock);
@@ -311,7 +311,7 @@ trait RejectTestTrait
     }
 
     /** @test */
-    public function alwaysShouldRejectWhenHandlerThrowsForRejection()
+    public function finallyShouldRejectWhenHandlerThrowsForRejection()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -324,7 +324,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->always(function () use ($exception) {
+            ->finally(function () use ($exception) {
                 throw $exception;
             })
             ->then(null, $mock);
@@ -333,7 +333,7 @@ trait RejectTestTrait
     }
 
     /** @test */
-    public function alwaysShouldRejectWhenHandlerRejectsForRejection()
+    public function finallyShouldRejectWhenHandlerRejectsForRejection()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -346,7 +346,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->always(function () use ($exception) {
+            ->finally(function () use ($exception) {
                 return reject($exception);
             })
             ->then(null, $mock);

--- a/tests/PromiseTest/ResolveTestTrait.php
+++ b/tests/PromiseTest/ResolveTestTrait.php
@@ -223,7 +223,7 @@ trait ResolveTestTrait
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressValue()
+    public function finallyShouldNotSuppressValue()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -236,14 +236,14 @@ trait ResolveTestTrait
             ->with($this->identicalTo($value));
 
         $adapter->promise()
-            ->always(function () {})
+            ->finally(function () {})
             ->then($mock);
 
         $adapter->resolve($value);
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressValueWhenHandlerReturnsANonPromise()
+    public function finallyShouldNotSuppressValueWhenHandlerReturnsANonPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -256,7 +256,7 @@ trait ResolveTestTrait
             ->with($this->identicalTo($value));
 
         $adapter->promise()
-            ->always(function () {
+            ->finally(function () {
                 return 1;
             })
             ->then($mock);
@@ -265,7 +265,7 @@ trait ResolveTestTrait
     }
 
     /** @test */
-    public function alwaysShouldNotSuppressValueWhenHandlerReturnsAPromise()
+    public function finallyShouldNotSuppressValueWhenHandlerReturnsAPromise()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -278,7 +278,7 @@ trait ResolveTestTrait
             ->with($this->identicalTo($value));
 
         $adapter->promise()
-            ->always(function () {
+            ->finally(function () {
                 return resolve(1);
             })
             ->then($mock);
@@ -287,7 +287,7 @@ trait ResolveTestTrait
     }
 
     /** @test */
-    public function alwaysShouldRejectWhenHandlerThrowsForFulfillment()
+    public function finallyShouldRejectWhenHandlerThrowsForFulfillment()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -300,7 +300,7 @@ trait ResolveTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->always(function () use ($exception) {
+            ->finally(function () use ($exception) {
                 throw $exception;
             })
             ->then(null, $mock);
@@ -309,7 +309,7 @@ trait ResolveTestTrait
     }
 
     /** @test */
-    public function alwaysShouldRejectWhenHandlerRejectsForFulfillment()
+    public function finallyShouldRejectWhenHandlerRejectsForFulfillment()
     {
         $adapter = $this->getPromiseTestAdapter();
 
@@ -322,7 +322,7 @@ trait ResolveTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->always(function () use ($exception) {
+            ->finally(function () use ($exception) {
                 return reject($exception);
             })
             ->then(null, $mock);


### PR DESCRIPTION
This changeset adds new `catch()` and `finally()` methods to the `PromiseInterface` and deprecates the `otherwise()` and `always()` methods. The underlying idea is to rename `otherwise()` to `catch()` and `always()` to `finally()`, but instead of performing a hard rename and causing a BC break, this changeset proposes deprecating the old method names and using them as an alias for the new method names.

```php
// old (deprecated)
$promise->otherwise($onRejected);
$promise->always($onFulfilledOrRejected);

// new
$promise->catch($onRejected);
$promise->finally($onFulfilledOrRejected);
```

The original method names have been added in #19 a while back. Back then, using the `catch()` and `finally()` method names was not possible as using reserved keywords is only supported as of PHP 7+. Promise v3 is PHP 7.1+ only (#138 / #149), so we can now use the method names that mimic a synchronous `try`/`catch`/`finally` block. Additionally, this also happens to be in line with ES6 promises as found in JavaScript.

Supersedes / closes #206, thanks @WyriHaximus for the original version! This PR follows the exact same idea with no functional difference, but adds additional documentation and duplicates all relevant test cases to achieve 100% code coverage for the affected code paths. Accordingly, there's a fair amount of duplication in the test suite now, which I consider a non-ideal but acceptable tradeoff. A potential promise v4 could remove this duplication at some point in the future.