### PR TITLE
Support intersection types (PHP 8.1+ / ported from v2 to v3)

### DIFF
--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -85,7 +85,37 @@ class FunctionCheckTypehintTest extends TestCase
         self::assertFalse(_checkTypehint([CallbackWithUnionTypehintClass::class, 'testCallbackStatic'], new Exception()));
     }
 
-/** @test */
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function shouldAcceptInvokableObjectCallbackWithIntersectionTypehint()
+    {
+        self::assertFalse(_checkTypehint(new CallbackWithIntersectionTypehintClass(), new \RuntimeException()));
+        self::assertTrue(_checkTypehint(new CallbackWithIntersectionTypehintClass(), new CountableException()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function shouldAcceptObjectMethodCallbackWithIntersectionTypehint()
+    {
+        self::assertFalse(_checkTypehint([new CallbackWithIntersectionTypehintClass(), 'testCallback'], new \RuntimeException()));
+        self::assertTrue(_checkTypehint([new CallbackWithIntersectionTypehintClass(), 'testCallback'], new CountableException()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8.1
+     */
+    public function shouldAcceptStaticClassCallbackWithIntersectionTypehint()
+    {
+        self::assertFalse(_checkTypehint([CallbackWithIntersectionTypehintClass::class, 'testCallbackStatic'], new \RuntimeException()));
+        self::assertTrue(_checkTypehint([CallbackWithIntersectionTypehintClass::class, 'testCallbackStatic'], new CountableException()));
+    }
+
+    /** @test */
     public function shouldAcceptClosureCallbackWithoutTypehint()
     {
         self::assertTrue(_checkTypehint(function (InvalidArgumentException $e) {

--- a/tests/fixtures/CallbackWithIntersectionTypehintClass.php
+++ b/tests/fixtures/CallbackWithIntersectionTypehintClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace React\Promise;
+
+use Countable;
+use RuntimeException;
+
+class CallbackWithIntersectionTypehintClass
+{
+    public function __invoke(RuntimeException&Countable $e)
+    {
+    }
+
+    public function testCallback(RuntimeException&Countable $e)
+    {
+    }
+
+    public static function testCallbackStatic(RuntimeException&Countable $e)
+    {
+    }
+}

--- a/tests/fixtures/CountableException.php
+++ b/tests/fixtures/CountableException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\Promise;
+
+use Countable;
+use RuntimeException;
+
+class CountableException extends RuntimeException implements Countable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+}
+


### PR DESCRIPTION
See #195 for details.

Unrelated: I fixed an E_DEPRECATED on 8.1 in `RejectedPromiseTest` (`Deprecated: Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated in /code/tests/Internal/RejectedPromiseTest.php on line 40`) - Are you fine with adding this in an additional commit to the PR or do you want to have a separate PR (and more rebase action)?