### PR TITLE
Improve test suite to fix default Exception message (PHP 8.1)

### DIFF
--- a/tests/Internal/RejectedPromiseTest.php
+++ b/tests/Internal/RejectedPromiseTest.php
@@ -34,7 +34,7 @@ class RejectedPromiseTest extends TestCase
                     $promise = new RejectedPromise($reason);
                 }
             },
-            'settle' => function ($reason = null) use (&$promise) {
+            'settle' => function ($reason = "") use (&$promise) {
                 if (!$promise) {
                     if (!$reason instanceof Exception) {
                         $reason = new Exception($reason);


### PR DESCRIPTION
PHP8.1+ complains about Exception not accepting `null` as the message argument for an `Exception` constructor. This fixes it.