### PR TITLE
Rename development branch to `3.x` and add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A lightweight implementation of
 
 [![CI status](https://github.com/reactphp/promise/workflows/CI/badge.svg)](https://github.com/reactphp/promise/actions)
 
-> The master branch contains the code for the upcoming 3.0 release.
-> For the code of the current stable 2.x release, checkout the 
-> [2.x branch](https://github.com/reactphp/promise/tree/2.x).
-
-> The upcoming 3.0 release will be the way forward for this package. 
-> However we will still actively support 2.0 and 1.0 for those not yet 
-> on PHP 7+.
+> **Development version:** This branch contains the code for the upcoming 3.0 release.
+> For the code of the current stable 2.x release, check out the
+> [`2.x` branch](https://github.com/reactphp/promise/tree/2.x).
+>
+> The upcoming 3.0 release will be the way forward for this package.
+> However, we will still actively support 2.0 and 1.0 for those not yet
+> on PHP 7.1+.
 
 Table of Contents
 -----------------
@@ -52,8 +52,9 @@ Table of Contents
      * [Rejection forwarding](#rejection-forwarding)
      * [Mixed resolution and rejection forwarding](#mixed-resolution-and-rejection-forwarding)
    * [done() vs. then()](#done-vs-then)
-5. [Credits](#credits)
-6. [License](#license)
+5. [Install](#install)
+6. [Credits](#credits)
+7. [License](#license)
 
 Introduction
 ------------
@@ -697,6 +698,37 @@ getJsonResult()
             }
         }
     );
+```
+
+Install
+-------
+
+The recommended way to install this library is [through Composer](https://getcomposer.org/).
+[New to Composer?](https://getcomposer.org/doc/00-intro.md)
+
+Once released, this project will follow [SemVer](https://semver.org/).
+At the moment, this will install the latest development version:
+
+```bash
+$ composer require react/promise:^3@dev
+```
+
+See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
+
+This project aims to run on any platform and thus does not require any PHP
+extensions and supports running on PHP 7.1 through current PHP 8+.
+It's *highly recommended to use the latest supported PHP version* for this project.
+
+We're committed to providing long-term support (LTS) options and to provide a
+smooth upgrade path. If you're using an older PHP version, you may use the
+[`2.x` branch](https://github.com/reactphp/promise/tree/2.x) (PHP 5.4+) or
+[`1.x` branch](https://github.com/reactphp/promise/tree/1.x) (PHP 5.3+) which both
+provide a compatible API but do not take advantage of newer language features.
+You may target multiple versions at the same time to support a wider range of
+PHP versions like this:
+
+```bash
+$ composer require "react/promise:^3@dev || ^2 || ^1"
 ```
 
 Credits


### PR DESCRIPTION
This changeset suggests renaming the development branch to `3.x` and adds appropriate installation instructions. In particular, this makes it much easier to install the v3 development version or any version like this:

```bash
$ composer require react/promise:^3@dev
$ composer require react/promise:"^3@dev || ^2 || ^1"
```

This has originally been brought up in #204 by @Seldaek, but instead of defining a branch alias, this PR suggests simply renaming what is currently `master` to `3.x`. This is in line with our existing `2.x` and `1.x` branches and means we do not have to update any alias definitions once we would start working on a potential future `4.x`.

From a consumer's perspective, this means installation is now much easier, as targeting `^3@dev` (or `3.x-dev`) is semantically more obvious and safer than using `dev-master`. Additionally, keep in mind that branch names are development artifacts that are subject to change at some point in the future. Once we would decide to rename or delete any of our version branches, the `^3@dev` reference would still be valid as it would also match stable versions if we have any `^3` tags at this point (which is safe to assume at this point).

Once this PR is merged, I will manually rename the `master` branch to `3.x`. At the same time, I also propose to set the current default branch to `2.x` until a stable 3.0.0 version has been released. This is more consistent with our website, which also renders the latest tagged release (2.x) instead of the latest development version (3.x). Once a stable 3.0.0 version is released, we should set the default branch to `3.x`.

Also refs https://github.com/reactphp/async/pull/14 and https://github.com/reactphp/async/pull/11 for similar branch names used in react/async.