### PR TITLE
Require argument for `resolve()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $deferred = new React\Promise\Deferred();
 
 $promise = $deferred->promise();
 
-$deferred->resolve(mixed $value = null);
+$deferred->resolve(mixed $value);
 $deferred->reject(\Throwable $reason);
 ```
 
@@ -119,7 +119,7 @@ keeping the authority to modify its state to yourself.
 #### Deferred::resolve()
 
 ```php
-$deferred->resolve(mixed $value = null);
+$deferred->resolve(mixed $value);
 ```
 
 Resolves the promise returned by `promise()`. All consumers are notified by

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -21,7 +21,7 @@ final class Deferred implements PromisorInterface
         return $this->promise;
     }
 
-    public function resolve($value = null): void
+    public function resolve($value): void
     {
         ($this->resolveCallback)($value);
     }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -239,7 +239,7 @@ final class Promise implements PromiseInterface
                 $target =& $this;
 
                 $callback(
-                    static function ($value = null) use (&$target) {
+                    static function ($value) use (&$target) {
                         if ($target !== null) {
                             $target->settle(resolve($value));
                             $target = null;

--- a/src/functions.php
+++ b/src/functions.php
@@ -20,8 +20,7 @@ use React\Promise\Internal\RejectedPromise;
  * @param mixed $promiseOrValue
  * @return PromiseInterface
  */
-
-function resolve($promiseOrValue = null): PromiseInterface
+function resolve($promiseOrValue): PromiseInterface
 {
     if ($promiseOrValue instanceof PromiseInterface) {
         return $promiseOrValue;
@@ -346,7 +345,7 @@ function _checkTypehint(callable $callback, \Throwable $reason): bool
 
     // Extract the type of the argument and handle different possibilities
     $type = $expectedException->getType();
-    
+
     $isTypeUnion = true;
     $types = [];
 

--- a/tests/FunctionAnyTest.php
+++ b/tests/FunctionAnyTest.php
@@ -122,7 +122,7 @@ class FunctionAnyTest extends TestCase
     public function shouldNotCancelOtherPendingInputArrayPromisesIfOnePromiseFulfills()
     {
         $deferred = new Deferred($this->expectCallableNever());
-        $deferred->resolve();
+        $deferred->resolve(null);
 
         $promise2 = new Promise(function () {}, $this->expectCallableNever());
 

--- a/tests/FunctionRaceTest.php
+++ b/tests/FunctionRaceTest.php
@@ -103,7 +103,7 @@ class FunctionRaceTest extends TestCase
     public function shouldNotCancelOtherPendingInputArrayPromisesIfOnePromiseFulfills()
     {
         $deferred = new Deferred($this->expectCallableNever());
-        $deferred->resolve();
+        $deferred->resolve(null);
 
         $promise2 = new Promise(function () {}, $this->expectCallableNever());
 

--- a/tests/FunctionSomeTest.php
+++ b/tests/FunctionSomeTest.php
@@ -148,7 +148,7 @@ class FunctionSomeTest extends TestCase
     public function shouldCancelOtherPendingInputArrayPromisesIfEnoughPromisesFulfill()
     {
         $deferred = new Deferred($this->expectCallableNever());
-        $deferred->resolve();
+        $deferred->resolve(null);
 
         $promise2 = new Promise(function () {}, $this->expectCallableNever());
 

--- a/tests/PromiseTest/CancelTestTrait.php
+++ b/tests/PromiseTest/CancelTestTrait.php
@@ -110,7 +110,7 @@ trait CancelTestTrait
             ->expects($this->once())
             ->method('__invoke')
             ->will($this->returnCallback(function ($resolve) {
-                $resolve();
+                $resolve(null);
             }));
 
         $adapter = $this->getPromiseTestAdapter($mock);

--- a/tests/PromiseTest/PromiseFulfilledTestTrait.php
+++ b/tests/PromiseTest/PromiseFulfilledTestTrait.php
@@ -190,7 +190,7 @@ trait PromiseFulfilledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->resolve();
+        $adapter->resolve(null);
 
         self::assertNull($adapter->promise()->cancel());
     }
@@ -200,7 +200,7 @@ trait PromiseFulfilledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter($this->expectCallableNever());
 
-        $adapter->resolve();
+        $adapter->resolve(null);
 
         $adapter->promise()->cancel();
     }

--- a/tests/PromiseTest/PromisePendingTestTrait.php
+++ b/tests/PromiseTest/PromisePendingTestTrait.php
@@ -57,7 +57,7 @@ trait PromisePendingTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         $adapter->promise()->catch($this->expectCallableNever());
     }
 
@@ -77,7 +77,7 @@ trait PromisePendingTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         $adapter->promise()->otherwise($this->expectCallableNever());
     }
 

--- a/tests/PromiseTest/PromiseRejectedTestTrait.php
+++ b/tests/PromiseTest/PromiseRejectedTestTrait.php
@@ -279,11 +279,11 @@ trait PromiseRejectedTestTrait
         $exception = new Exception('UnhandledRejectionException');
 
         $d = new Deferred();
-        $d->resolve();
+        $d->resolve(null);
 
         $result = resolve(resolve($d->promise()->then(function () use ($exception) {
             $d = new Deferred();
-            $d->resolve();
+            $d->resolve(null);
 
             return resolve($d->promise()->then(function () {}))->then(
                 function () use ($exception) {

--- a/tests/PromiseTest/PromiseSettledTestTrait.php
+++ b/tests/PromiseTest/PromiseSettledTestTrait.php
@@ -17,7 +17,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->then());
     }
 
@@ -26,7 +26,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->then(null, null));
     }
 
@@ -35,7 +35,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
 
         self::assertNull($adapter->promise()->cancel());
     }
@@ -45,7 +45,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter($this->expectCallableNever());
 
-        $adapter->settle();
+        $adapter->settle(null);
 
         $adapter->promise()->cancel();
     }
@@ -55,7 +55,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         self::assertNull($adapter->promise()->done(null, function () {}));
     }
 
@@ -64,7 +64,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         self::assertNull($adapter->promise()->done(null, function () {}, null));
     }
 
@@ -73,7 +73,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->finally(function () {}));
     }
 
@@ -85,7 +85,7 @@ trait PromiseSettledTestTrait
     {
         $adapter = $this->getPromiseTestAdapter();
 
-        $adapter->settle();
+        $adapter->settle(null);
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->always(function () {}));
     }
 }

--- a/tests/PromiseTest/RejectTestTrait.php
+++ b/tests/PromiseTest/RejectTestTrait.php
@@ -216,7 +216,7 @@ trait RejectTestTrait
 
         $result = resolve(resolve($d->promise()->then(function () use ($exception) {
             $d = new Deferred();
-            $d->resolve();
+            $d->resolve(null);
 
             return resolve($d->promise()->then(function () {}))->then(
                 function () use ($exception) {
@@ -227,7 +227,7 @@ trait RejectTestTrait
 
         $result->done();
 
-        $d->resolve();
+        $d->resolve(null);
 
         $errors = $errorCollector->stop();
 


### PR DESCRIPTION
This changeset updates the `resolve()` and `$deferred->resolve()` signature to require a value instead of having a `null` default value. This is mostly done for consistently with how ES6 promises in JavaScript also always require this argument and how our `reject()` signature now always requires a `Throwable` as of #138.

```php
// unchanged
$promise = resolve($value);
$deferred->resolve($value);

// old
$promise = resolve();
$deferred->resolve();

// new
$promise = resolve(null);
$deferred->resolve(null);
```

Most promises would usually be resolved with some kind of value, so this shouldn't affect most consumers. By requiring this as an input argument we can be more type safe with how the promise API always fulfills with a value as an output (refs #188).