### PR TITLE
[1.x] Add badge to show number of project installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A lightweight implementation of
 [CommonJS Promises/A](http://wiki.commonjs.org/wiki/Promises/A) for PHP.
 
 [![CI status](https://github.com/reactphp/promise/workflows/CI/badge.svg?branch=1.x)](https://github.com/reactphp/promise/actions)
+[![installs on Packagist](https://img.shields.io/packagist/dt/react/promise?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/react/promise)
 
 Table of Contents
 -----------------


### PR DESCRIPTION
This PR adds a badge with the number of installation on packagist to the README.

Builds on top of reactphp/socket#285.