### PR TITLE
Support `iterable` type for `all()` + `race()` + `any()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ reject a promise, any language error or user land exception can be used to rejec
 #### all()
 
 ```php
-$promise = React\Promise\all(array $promisesOrValues);
+$promise = React\Promise\all(iterable $promisesOrValues);
 ```
 
 Returns a promise that will resolve only once all the items in
@@ -387,7 +387,7 @@ will be an array containing the resolution values of each of the items in
 #### race()
 
 ```php
-$promise = React\Promise\race(array $promisesOrValues);
+$promise = React\Promise\race(iterable $promisesOrValues);
 ```
 
 Initiates a competitive race that allows one winner. Returns a promise which is
@@ -399,7 +399,7 @@ contains 0 items.
 #### any()
 
 ```php
-$promise = React\Promise\any(array $promisesOrValues);
+$promise = React\Promise\any(iterable $promisesOrValues);
 ```
 
 Returns a promise that will resolve when any one of the items in

--- a/src/functions.php
+++ b/src/functions.php
@@ -68,11 +68,15 @@ function reject(\Throwable $reason): PromiseInterface
  * will be an array containing the resolution values of each of the items in
  * `$promisesOrValues`.
  *
- * @param array $promisesOrValues
+ * @param iterable $promisesOrValues
  * @return PromiseInterface
  */
-function all(array $promisesOrValues): PromiseInterface
+function all(iterable $promisesOrValues): PromiseInterface
 {
+    if (!\is_array($promisesOrValues)) {
+        $promisesOrValues = \iterator_to_array($promisesOrValues);
+    }
+
     if (!$promisesOrValues) {
         return resolve([]);
     }
@@ -109,11 +113,15 @@ function all(array $promisesOrValues): PromiseInterface
  * The returned promise will become **infinitely pending** if  `$promisesOrValues`
  * contains 0 items.
  *
- * @param array $promisesOrValues
+ * @param iterable $promisesOrValues
  * @return PromiseInterface
  */
-function race(array $promisesOrValues): PromiseInterface
+function race(iterable $promisesOrValues): PromiseInterface
 {
+    if (!\is_array($promisesOrValues)) {
+        $promisesOrValues = \iterator_to_array($promisesOrValues);
+    }
+
     if (!$promisesOrValues) {
         return new Promise(function (): void {});
     }
@@ -141,18 +149,22 @@ function race(array $promisesOrValues): PromiseInterface
  * The returned promise will also reject with a `React\Promise\Exception\LengthException`
  * if `$promisesOrValues` contains 0 items.
  *
- * @param array $promisesOrValues
+ * @param iterable $promisesOrValues
  * @return PromiseInterface
  */
-function any(array $promisesOrValues): PromiseInterface
+function any(iterable $promisesOrValues): PromiseInterface
 {
+    if (!\is_array($promisesOrValues)) {
+        $promisesOrValues = \iterator_to_array($promisesOrValues);
+    }
+
     $len = \count($promisesOrValues);
 
     if (!$promisesOrValues) {
         return reject(
             new Exception\LengthException(
                 \sprintf(
-                    'Input array must contain at least 1 item but contains only %s item%s.',
+                    'Must contain at least 1 item but contains only %s item%s.',
                     $len,
                     1 === $len ? '' : 's'
                 )

--- a/tests/FunctionAllTest.php
+++ b/tests/FunctionAllTest.php
@@ -77,6 +77,24 @@ class FunctionAllTest extends TestCase
     }
 
     /** @test */
+    public function shouldResolveValuesGeneratorEmpty()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(self::identicalTo([]));
+
+        $gen = (function () {
+            if (false) {
+                yield;
+            }
+        })();
+
+        all($gen)->then($mock);
+    }
+
+    /** @test */
     public function shouldRejectIfAnyInputPromiseRejects()
     {
         $exception2 = new Exception();
@@ -90,6 +108,24 @@ class FunctionAllTest extends TestCase
 
         all([resolve(1), reject($exception2), resolve($exception3)])
             ->then($this->expectCallableNever(), $mock);
+    }
+
+    /** @test */
+    public function shouldRejectInfiteGeneratorOrRejectedPromises()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(new \RuntimeException('Iteration 1'));
+
+        $gen = (function () {
+            for ($i = 1; ; ++$i) {
+                yield reject(new \RuntimeException('Iteration ' . $i));
+            }
+        })();
+
+        all($gen)->then(null, $mock);
     }
 
     /** @test */

--- a/tests/FunctionAllTest.php
+++ b/tests/FunctionAllTest.php
@@ -59,6 +59,24 @@ class FunctionAllTest extends TestCase
     }
 
     /** @test */
+    public function shouldResolveValuesGenerator()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(self::identicalTo([1, 2, 3]));
+
+        $gen = (function () {
+            for ($i = 1; $i <= 3; ++$i) {
+                yield $i;
+            }
+        })();
+
+        all($gen)->then($mock);
+    }
+
+    /** @test */
     public function shouldRejectIfAnyInputPromiseRejects()
     {
         $exception2 = new Exception();

--- a/tests/FunctionAnyTest.php
+++ b/tests/FunctionAnyTest.php
@@ -18,7 +18,7 @@ class FunctionAnyTest extends TestCase
             ->with(
                 self::callback(function ($exception) {
                     return $exception instanceof LengthException &&
-                           'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
+                           'Must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
                 })
             );
 
@@ -50,6 +50,24 @@ class FunctionAnyTest extends TestCase
 
         any([resolve(1), resolve(2), resolve(3)])
             ->then($mock);
+    }
+
+    /** @test */
+    public function shouldResolveValuesGenerator()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(self::identicalTo(1));
+
+        $gen = (function () {
+            for ($i = 1; $i <= 3; ++$i) {
+                yield $i;
+            }
+        })();
+
+        any($gen)->then($mock);
     }
 
     /** @test */

--- a/tests/FunctionRaceTest.php
+++ b/tests/FunctionRaceTest.php
@@ -66,6 +66,24 @@ class FunctionRaceTest extends TestCase
     }
 
     /** @test */
+    public function shouldResolveValuesGenerator()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(self::identicalTo(1));
+
+        $gen = (function () {
+            for ($i = 1; $i <= 3; ++$i) {
+                yield $i;
+            }
+        })();
+
+        race($gen)->then($mock);
+    }
+
+    /** @test */
     public function shouldRejectIfFirstSettledPromiseRejects()
     {
         $exception = new Exception();

--- a/tests/FunctionRaceTest.php
+++ b/tests/FunctionRaceTest.php
@@ -84,6 +84,24 @@ class FunctionRaceTest extends TestCase
     }
 
     /** @test */
+    public function shouldResolveValuesInfiniteGenerator()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(self::identicalTo(1));
+
+        $gen = (function () {
+            for ($i = 1; ; ++$i) {
+                yield $i;
+            }
+        })();
+
+        race($gen)->then($mock);
+    }
+
+    /** @test */
     public function shouldRejectIfFirstSettledPromiseRejects()
     {
         $exception = new Exception();


### PR DESCRIPTION
This changeset adds support for the `iterable` type for `all()` + `race()` + `any()`. Instead of only accepting an `array`, each function now also accepts instances implementing `Traversable` such as `Iterator` and `Generator` instances.

This is a pure feature addition that does not break BC. With these changes applied, our API is also pretty much identical to ES6 promises commonly used in JavaScript.

The first commit highlights how this is essentially only a new type definition and a call to `iterator_to_array()`. The second commit then takes advantage of a more iterative approach that uses less memory and also supports consuming infinite iterators if the resulting promise settles. The test suite confirms this has 100% code coverage.

Resolves #221
Builds on top of #149, #35, #83, #219 and others