### PR TITLE
[3.x] feat: add support for DNF types

### DIFF
--- a/tests/FunctionCheckTypehintTest.php
+++ b/tests/FunctionCheckTypehintTest.php
@@ -115,6 +115,39 @@ class FunctionCheckTypehintTest extends TestCase
         self::assertTrue(_checkTypehint([CallbackWithIntersectionTypehintClass::class, 'testCallbackStatic'], new CountableException()));
     }
 
+    /**
+     * @test
+     * @requires PHP 8.2
+     */
+    public function shouldAcceptInvokableObjectCallbackWithDNFTypehint()
+    {
+        self::assertFalse(_checkTypehint(new CallbackWithDNFTypehintClass(), new \RuntimeException()));
+        self::assertTrue(_checkTypehint(new CallbackWithDNFTypehintClass(), new ArrayAccessibleException()));
+        self::assertTrue(_checkTypehint(new CallbackWithDNFTypehintClass(), new CountableException()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8.2
+     */
+    public function shouldAcceptObjectMethodCallbackWithDNFTypehint()
+    {
+        self::assertFalse(_checkTypehint([new CallbackWithDNFTypehintClass(), 'testCallback'], new \RuntimeException()));
+        self::assertTrue(_checkTypehint([new CallbackWithDNFTypehintClass(), 'testCallback'], new CountableException()));
+        self::assertTrue(_checkTypehint([new CallbackWithDNFTypehintClass(), 'testCallback'], new ArrayAccessibleException()));
+    }
+
+    /**
+     * @test
+     * @requires PHP 8.2
+     */
+    public function shouldAcceptStaticClassCallbackWithDNFTypehint()
+    {
+        self::assertFalse(_checkTypehint([CallbackWithDNFTypehintClass::class, 'testCallbackStatic'], new \RuntimeException()));
+        self::assertTrue(_checkTypehint([CallbackWithDNFTypehintClass::class, 'testCallbackStatic'], new CountableException()));
+        self::assertTrue(_checkTypehint([CallbackWithDNFTypehintClass::class, 'testCallbackStatic'], new ArrayAccessibleException()));
+    }
+
     /** @test */
     public function shouldAcceptClosureCallbackWithoutTypehint()
     {

--- a/tests/fixtures/ArrayAccessibleException.php
+++ b/tests/fixtures/ArrayAccessibleException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace React\Promise;
+
+use RuntimeException;
+
+class ArrayAccessibleException extends RuntimeException implements \ArrayAccess
+{
+    public function offsetExists(mixed $offset): bool
+    {
+        return true;
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $offset;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void {}
+
+    public function offsetUnset(mixed $offset): void {}
+}

--- a/tests/fixtures/CallbackWithDNFTypehintClass.php
+++ b/tests/fixtures/CallbackWithDNFTypehintClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace React\Promise;
+
+use Countable;
+use RuntimeException;
+
+class CallbackWithDNFTypehintClass
+{
+    public function __invoke((RuntimeException&Countable)|(RuntimeException&\ArrayAccess) $e)
+    {
+    }
+
+    public function testCallback((RuntimeException&Countable)|(RuntimeException&\ArrayAccess) $e)
+    {
+    }
+
+    public static function testCallbackStatic((RuntimeException&Countable)|(RuntimeException&\ArrayAccess) $e)
+    {
+    }
+}


### PR DESCRIPTION
This PR adds support for Disjunctive Normal Form Types (DNF types) when using PHP 8.2.

### Overview of the changes

- [x] Removes the previous guard that would only allow `ReflectionNamedType` to be analyzed.
- [x] ~Adds two new **internal** functions `matchesType` and `matchesAllTypes` to extract common functionality.~
- [x] Adds tests + supporting fixtures

Please let me know if you think that I missed something.

---

Closes #235 