### PR TITLE
[3.x] Add template annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
           - 7.4
           - 7.3
           - 7.2
-          - 7.1
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -2,9 +2,14 @@
 
 namespace React\Promise;
 
+/**
+ * @template T
+ */
 final class Deferred
 {
-    /** @var Promise */
+    /**
+     * @var PromiseInterface<T>
+     */
     private $promise;
 
     /** @var callable */
@@ -21,13 +26,16 @@ final class Deferred
         }, $canceller);
     }
 
+    /**
+     * @return PromiseInterface<T>
+     */
     public function promise(): PromiseInterface
     {
         return $this->promise;
     }
 
     /**
-     * @param mixed $value
+     * @param T $value
      */
     public function resolve($value): void
     {

--- a/src/Internal/FulfilledPromise.php
+++ b/src/Internal/FulfilledPromise.php
@@ -7,14 +7,17 @@ use function React\Promise\resolve;
 
 /**
  * @internal
+ *
+ * @template T
+ * @template-implements PromiseInterface<T>
  */
 final class FulfilledPromise implements PromiseInterface
 {
-    /** @var mixed */
+    /** @var T */
     private $value;
 
     /**
-     * @param mixed $value
+     * @param T $value
      * @throws \InvalidArgumentException
      */
     public function __construct($value = null)
@@ -26,6 +29,11 @@ final class FulfilledPromise implements PromiseInterface
         $this->value = $value;
     }
 
+    /**
+     * @template TFulfilled
+     * @param ?(callable((T is void ? null : T)): (PromiseInterface<TFulfilled>|TFulfilled)) $onFulfilled
+     * @return PromiseInterface<($onFulfilled is null ? T : TFulfilled)>
+     */
     public function then(callable $onFulfilled = null, callable $onRejected = null): PromiseInterface
     {
         if (null === $onFulfilled) {
@@ -33,7 +41,11 @@ final class FulfilledPromise implements PromiseInterface
         }
 
         try {
-            return resolve($onFulfilled($this->value));
+            /**
+             * @var PromiseInterface<T>|T $result
+             */
+            $result = $onFulfilled($this->value);
+            return resolve($result);
         } catch (\Throwable $exception) {
             return new RejectedPromise($exception);
         }

--- a/src/Internal/RejectedPromise.php
+++ b/src/Internal/RejectedPromise.php
@@ -8,6 +8,8 @@ use function React\Promise\resolve;
 
 /**
  * @internal
+ *
+ * @template-implements PromiseInterface<never>
  */
 final class RejectedPromise implements PromiseInterface
 {
@@ -37,6 +39,12 @@ final class RejectedPromise implements PromiseInterface
         \error_log($message);
     }
 
+    /**
+     * @template TRejected
+     * @param ?callable $onFulfilled
+     * @param ?(callable(\Throwable): (PromiseInterface<TRejected>|TRejected)) $onRejected
+     * @return PromiseInterface<($onRejected is null ? never : TRejected)>
+     */
     public function then(callable $onFulfilled = null, callable $onRejected = null): PromiseInterface
     {
         if (null === $onRejected) {
@@ -52,12 +60,21 @@ final class RejectedPromise implements PromiseInterface
         }
     }
 
+    /**
+     * @template TThrowable of \Throwable
+     * @template TRejected
+     * @param callable(TThrowable): (PromiseInterface<TRejected>|TRejected) $onRejected
+     * @return PromiseInterface<TRejected>
+     */
     public function catch(callable $onRejected): PromiseInterface
     {
         if (!_checkTypehint($onRejected, $this->reason)) {
             return $this;
         }
 
+        /**
+         * @var callable(\Throwable):(PromiseInterface<TRejected>|TRejected) $onRejected
+         */
         return $this->then(null, $onRejected);
     }
 

--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -2,6 +2,9 @@
 
 namespace React\Promise;
 
+/**
+ * @template-covariant T
+ */
 interface PromiseInterface
 {
     /**
@@ -28,9 +31,11 @@ interface PromiseInterface
      *  2. `$onFulfilled` and `$onRejected` will never be called more
      *      than once.
      *
-     * @param callable|null $onFulfilled
-     * @param callable|null $onRejected
-     * @return PromiseInterface
+     * @template TFulfilled
+     * @template TRejected
+     * @param ?(callable((T is void ? null : T)): (PromiseInterface<TFulfilled>|TFulfilled)) $onFulfilled
+     * @param ?(callable(\Throwable): (PromiseInterface<TRejected>|TRejected)) $onRejected
+     * @return PromiseInterface<($onRejected is null ? ($onFulfilled is null ? T : TFulfilled) : ($onFulfilled is null ? T|TRejected : TFulfilled|TRejected))>
      */
     public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface;
 
@@ -44,8 +49,10 @@ interface PromiseInterface
      * Additionally, you can type hint the `$reason` argument of `$onRejected` to catch
      * only specific errors.
      *
-     * @param callable $onRejected
-     * @return PromiseInterface
+     * @template TThrowable of \Throwable
+     * @template TRejected
+     * @param callable(TThrowable): (PromiseInterface<TRejected>|TRejected) $onRejected
+     * @return PromiseInterface<T|TRejected>
      */
     public function catch(callable $onRejected): PromiseInterface;
 
@@ -91,8 +98,8 @@ interface PromiseInterface
      *     ->finally('cleanup');
      * ```
      *
-     * @param callable $onFulfilledOrRejected
-     * @return PromiseInterface
+     * @param callable(): (void|PromiseInterface<void>) $onFulfilledOrRejected
+     * @return PromiseInterface<T>
      */
     public function finally(callable $onFulfilledOrRejected): PromiseInterface;
 
@@ -117,8 +124,10 @@ interface PromiseInterface
      * $promise->catch($onRejected);
      * ```
      *
-     * @param callable $onRejected
-     * @return PromiseInterface
+     * @template TThrowable of \Throwable
+     * @template TRejected
+     * @param callable(TThrowable): (PromiseInterface<TRejected>|TRejected) $onRejected
+     * @return PromiseInterface<T|TRejected>
      * @deprecated 3.0.0 Use catch() instead
      * @see self::catch()
      */
@@ -134,8 +143,8 @@ interface PromiseInterface
      * $promise->finally($onFulfilledOrRejected);
      * ```
      *
-     * @param callable $onFulfilledOrRejected
-     * @return PromiseInterface
+     * @param callable(): (void|PromiseInterface<void>) $onFulfilledOrRejected
+     * @return PromiseInterface<T>
      * @deprecated 3.0.0 Use finally() instead
      * @see self::finally()
      */

--- a/src/functions.php
+++ b/src/functions.php
@@ -17,8 +17,9 @@ use React\Promise\Internal\RejectedPromise;
  *
  * If `$promiseOrValue` is a promise, it will be returned as is.
  *
- * @param mixed $promiseOrValue
- * @return PromiseInterface
+ * @template T
+ * @param PromiseInterface<T>|T $promiseOrValue
+ * @return PromiseInterface<T>
  */
 function resolve($promiseOrValue): PromiseInterface
 {
@@ -31,6 +32,7 @@ function resolve($promiseOrValue): PromiseInterface
 
         if (\method_exists($promiseOrValue, 'cancel')) {
             $canceller = [$promiseOrValue, 'cancel'];
+            assert(\is_callable($canceller));
         }
 
         return new Promise(function ($resolve, $reject) use ($promiseOrValue): void {
@@ -54,8 +56,7 @@ function resolve($promiseOrValue): PromiseInterface
  * throwing an exception. For example, it allows you to propagate a rejection with
  * the value of another promise.
  *
- * @param \Throwable $reason
- * @return PromiseInterface
+ * @return PromiseInterface<never>
  */
 function reject(\Throwable $reason): PromiseInterface
 {
@@ -68,8 +69,9 @@ function reject(\Throwable $reason): PromiseInterface
  * will be an array containing the resolution values of each of the items in
  * `$promisesOrValues`.
  *
- * @param iterable<mixed> $promisesOrValues
- * @return PromiseInterface
+ * @template T
+ * @param iterable<PromiseInterface<T>|T> $promisesOrValues
+ * @return PromiseInterface<array<T>>
  */
 function all(iterable $promisesOrValues): PromiseInterface
 {
@@ -119,14 +121,15 @@ function all(iterable $promisesOrValues): PromiseInterface
  * The returned promise will become **infinitely pending** if  `$promisesOrValues`
  * contains 0 items.
  *
- * @param iterable<mixed> $promisesOrValues
- * @return PromiseInterface
+ * @template T
+ * @param iterable<PromiseInterface<T>|T> $promisesOrValues
+ * @return PromiseInterface<T>
  */
 function race(iterable $promisesOrValues): PromiseInterface
 {
     $cancellationQueue = new Internal\CancellationQueue();
 
-    return new Promise(function ($resolve, $reject) use ($promisesOrValues, $cancellationQueue): void {
+    return new Promise(function (callable $resolve, callable $reject) use ($promisesOrValues, $cancellationQueue): void {
         $continue = true;
 
         foreach ($promisesOrValues as $promiseOrValue) {
@@ -154,8 +157,9 @@ function race(iterable $promisesOrValues): PromiseInterface
  * The returned promise will also reject with a `React\Promise\Exception\LengthException`
  * if `$promisesOrValues` contains 0 items.
  *
- * @param iterable<mixed> $promisesOrValues
- * @return PromiseInterface
+ * @template T
+ * @param iterable<PromiseInterface<T>|T> $promisesOrValues
+ * @return PromiseInterface<T>
  */
 function any(iterable $promisesOrValues): PromiseInterface
 {

--- a/tests/DeferredTest.php
+++ b/tests/DeferredTest.php
@@ -4,10 +4,16 @@ namespace React\Promise;
 
 use React\Promise\PromiseAdapter\CallbackPromiseAdapter;
 
+/**
+ * @template T
+ */
 class DeferredTest extends TestCase
 {
     use PromiseTest\FullTestTrait;
 
+    /**
+     * @return CallbackPromiseAdapter<T>
+     */
     public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
     {
         $d = new Deferred($canceller);
@@ -54,7 +60,7 @@ class DeferredTest extends TestCase
         gc_collect_cycles();
         gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
 
-        /** @var Deferred $deferred */
+        /** @var Deferred<never> $deferred */
         $deferred = new Deferred(function () use (&$deferred) {
             assert($deferred instanceof Deferred);
         });

--- a/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp7.phpt
+++ b/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp7.phpt
@@ -12,7 +12,7 @@ use function React\Promise\reject;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueException $unexpected): void {
+reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueException $unexpected): void { // @phpstan-ignore-line
     echo 'This will never be shown because the types do not match' . PHP_EOL;
 });
 

--- a/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
+++ b/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
@@ -12,7 +12,7 @@ use function React\Promise\reject;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueException $unexpected): void {
+reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueException $unexpected): void { // @phpstan-ignore-line
     echo 'This will never be shown because the types do not match' . PHP_EOL;
 });
 

--- a/tests/Internal/CancellationQueueTest.php
+++ b/tests/Internal/CancellationQueueTest.php
@@ -96,6 +96,9 @@ class CancellationQueueTest extends TestCase
         $cancellationQueue();
     }
 
+    /**
+     * @return Deferred<never>
+     */
     private function getCancellableDeferred(): Deferred
     {
         return new Deferred($this->expectCallableOnce());

--- a/tests/Internal/FulfilledPromiseTest.php
+++ b/tests/Internal/FulfilledPromiseTest.php
@@ -9,14 +9,20 @@ use React\Promise\PromiseTest\PromiseFulfilledTestTrait;
 use React\Promise\PromiseTest\PromiseSettledTestTrait;
 use React\Promise\TestCase;
 
+/**
+ * @template T
+ */
 class FulfilledPromiseTest extends TestCase
 {
     use PromiseSettledTestTrait,
         PromiseFulfilledTestTrait;
 
+    /**
+     * @return CallbackPromiseAdapter<T>
+     */
     public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
     {
-        /** @var ?FulfilledPromise */
+        /** @var ?FulfilledPromise<T> */
         $promise = null;
 
         return new CallbackPromiseAdapter([

--- a/tests/Internal/RejectedPromiseTest.php
+++ b/tests/Internal/RejectedPromiseTest.php
@@ -14,6 +14,9 @@ class RejectedPromiseTest extends TestCase
     use PromiseSettledTestTrait,
         PromiseRejectedTestTrait;
 
+    /**
+     * @return CallbackPromiseAdapter<never>
+     */
     public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
     {
         /** @var ?RejectedPromise */

--- a/tests/PromiseAdapter/CallbackPromiseAdapter.php
+++ b/tests/PromiseAdapter/CallbackPromiseAdapter.php
@@ -4,6 +4,10 @@ namespace React\Promise\PromiseAdapter;
 
 use React\Promise\PromiseInterface;
 
+/**
+ * @template T
+ * @template-implements PromiseAdapterInterface<T>
+ */
 class CallbackPromiseAdapter implements PromiseAdapterInterface
 {
     /** @var callable[] */
@@ -17,12 +21,15 @@ class CallbackPromiseAdapter implements PromiseAdapterInterface
         $this->callbacks = $callbacks;
     }
 
+    /**
+     * @return PromiseInterface<T>
+     */
     public function promise(): PromiseInterface
     {
         return ($this->callbacks['promise'])(...func_get_args());
     }
 
-    public function resolve(): void
+    public function resolve($value): void
     {
         ($this->callbacks['resolve'])(...func_get_args());
     }

--- a/tests/PromiseAdapter/PromiseAdapterInterface.php
+++ b/tests/PromiseAdapter/PromiseAdapterInterface.php
@@ -4,10 +4,20 @@ namespace React\Promise\PromiseAdapter;
 
 use React\Promise\PromiseInterface;
 
+/**
+ * @template T
+ */
 interface PromiseAdapterInterface
 {
+    /**
+     * @return PromiseInterface<T>
+     */
     public function promise(): PromiseInterface;
-    public function resolve(): void;
+
+    /**
+     * @param mixed $value
+     */
+    public function resolve($value): void;
     public function reject(): void;
     public function settle(): void;
 }

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -5,10 +5,16 @@ namespace React\Promise;
 use Exception;
 use React\Promise\PromiseAdapter\CallbackPromiseAdapter;
 
+/**
+ * @template T
+ */
 class PromiseTest extends TestCase
 {
     use PromiseTest\FullTestTrait;
 
+    /**
+     * @return CallbackPromiseAdapter<T>
+     */
     public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
     {
         $resolveCallback = $rejectCallback = null;
@@ -146,7 +152,7 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerWithReferenceThrowsException(): void
     {
         gc_collect_cycles();
-        /** @var Promise $promise */
+        /** @var Promise<never> $promise */
         $promise = new Promise(function () {}, function () use (&$promise) {
             assert($promise instanceof Promise);
             throw new \Exception('foo');
@@ -165,7 +171,7 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfResolverWithReferenceThrowsException(): void
     {
         gc_collect_cycles();
-        /** @var Promise $promise */
+        /** @var Promise<never> $promise */
         $promise = new Promise(function () use (&$promise) {
             assert($promise instanceof Promise);
             throw new \Exception('foo');
@@ -186,7 +192,7 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerHoldsReferenceAndResolverThrowsException(): void
     {
         gc_collect_cycles();
-        /** @var Promise $promise */
+        /** @var Promise<never> $promise */
         $promise = new Promise(function () {
             throw new \Exception('foo');
         }, function () use (&$promise) {

--- a/tests/PromiseTest/PromiseFulfilledTestTrait.php
+++ b/tests/PromiseTest/PromiseFulfilledTestTrait.php
@@ -4,6 +4,7 @@ namespace React\Promise\PromiseTest;
 
 use Exception;
 use React\Promise\PromiseAdapter\PromiseAdapterInterface;
+use React\Promise\PromiseInterface;
 use stdClass;
 use function React\Promise\reject;
 use function React\Promise\resolve;
@@ -187,6 +188,7 @@ trait PromiseFulfilledTestTrait
      */
     public function thenShouldContinueToExecuteCallbacksWhenPriorCallbackSuspendsFiber(): void
     {
+        /** @var PromiseAdapterInterface<int> $adapter */
         $adapter = $this->getPromiseTestAdapter();
         $adapter->resolve(42);
 
@@ -261,7 +263,7 @@ trait PromiseFulfilledTestTrait
 
         $adapter->resolve($value);
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): int { // @phpstan-ignore-line
                 return 1;
             })
             ->then($mock);
@@ -282,7 +284,7 @@ trait PromiseFulfilledTestTrait
 
         $adapter->resolve($value);
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): PromiseInterface { // @phpstan-ignore-line
                 return resolve(1);
             })
             ->then($mock);
@@ -382,7 +384,7 @@ trait PromiseFulfilledTestTrait
 
         $adapter->resolve($value);
         $adapter->promise()
-            ->always(function () {
+            ->always(function (): int { // @phpstan-ignore-line
                 return 1;
             })
             ->then($mock);
@@ -406,7 +408,7 @@ trait PromiseFulfilledTestTrait
 
         $adapter->resolve($value);
         $adapter->promise()
-            ->always(function () {
+            ->always(function (): PromiseInterface { // @phpstan-ignore-line
                 return resolve(1);
             })
             ->then($mock);

--- a/tests/PromiseTest/PromiseRejectedTestTrait.php
+++ b/tests/PromiseTest/PromiseRejectedTestTrait.php
@@ -5,6 +5,7 @@ namespace React\Promise\PromiseTest;
 use Exception;
 use InvalidArgumentException;
 use React\Promise\PromiseAdapter\PromiseAdapterInterface;
+use React\Promise\PromiseInterface;
 use function React\Promise\reject;
 use function React\Promise\resolve;
 
@@ -298,7 +299,7 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): int { // @phpstan-ignore-line
                 return 1;
             })
             ->then(null, $mock);
@@ -319,7 +320,7 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): PromiseInterface { // @phpstan-ignore-line
                 return resolve(1);
             })
             ->then(null, $mock);
@@ -504,7 +505,7 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-        ->finally(function () {
+        ->finally(function (): int { // @phpstan-ignore-line
             return 1;
         })
         ->then(null, $mock);
@@ -528,7 +529,7 @@ trait PromiseRejectedTestTrait
 
         $adapter->reject($exception);
         $adapter->promise()
-            ->always(function () {
+            ->always(function (): PromiseInterface { // @phpstan-ignore-line
                 return resolve(1);
             })
             ->then(null, $mock);

--- a/tests/PromiseTest/RejectTestTrait.php
+++ b/tests/PromiseTest/RejectTestTrait.php
@@ -6,6 +6,7 @@ use Exception;
 use React\Promise;
 use React\Promise\Deferred;
 use React\Promise\PromiseAdapter\PromiseAdapterInterface;
+use React\Promise\PromiseInterface;
 use function React\Promise\reject;
 use function React\Promise\resolve;
 
@@ -73,7 +74,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception1));
 
         $adapter->promise()
-            ->then(null, function ($value) use ($exception3, $adapter) {
+            ->then(null, function (\Throwable $value) use ($exception3, $adapter): PromiseInterface {
                 $adapter->reject($exception3);
 
                 return reject($value);
@@ -140,7 +141,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): int { // @phpstan-ignore-line
                 return 1;
             })
             ->then(null, $mock);
@@ -162,7 +163,7 @@ trait RejectTestTrait
             ->with($this->identicalTo($exception));
 
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): PromiseInterface { // @phpstan-ignore-line
                 return resolve(1);
             })
             ->then(null, $mock);

--- a/tests/PromiseTest/ResolveTestTrait.php
+++ b/tests/PromiseTest/ResolveTestTrait.php
@@ -6,6 +6,7 @@ use Exception;
 use LogicException;
 use React\Promise;
 use React\Promise\PromiseAdapter\PromiseAdapterInterface;
+use React\Promise\PromiseInterface;
 use stdClass;
 use function React\Promise\reject;
 use function React\Promise\resolve;
@@ -200,7 +201,7 @@ trait ResolveTestTrait
             ->with($this->identicalTo($value));
 
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): int { // @phpstan-ignore-line
                 return 1;
             })
             ->then($mock);
@@ -222,7 +223,7 @@ trait ResolveTestTrait
             ->with($this->identicalTo($value));
 
         $adapter->promise()
-            ->finally(function () {
+            ->finally(function (): PromiseInterface { // @phpstan-ignore-line
                 return resolve(1);
             })
             ->then($mock);

--- a/tests/types/all.php
+++ b/tests/types/all.php
@@ -1,0 +1,10 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+use function React\Promise\all;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<array<bool>>', all([resolve(true), resolve(false)]));
+assertType('React\Promise\PromiseInterface<array<bool>>', all([resolve(true), false]));
+assertType('React\Promise\PromiseInterface<array<bool|int>>', all([true, time()]));
+assertType('React\Promise\PromiseInterface<array<bool|int>>', all([resolve(true), resolve(time())]));

--- a/tests/types/any.php
+++ b/tests/types/any.php
@@ -1,0 +1,10 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+use function React\Promise\any;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<bool>', any([resolve(true), resolve(false)]));
+assertType('React\Promise\PromiseInterface<bool>', any([resolve(true), false]));
+assertType('React\Promise\PromiseInterface<bool|int>', any([true, time()]));
+assertType('React\Promise\PromiseInterface<bool|int>', any([resolve(true), resolve(time())]));

--- a/tests/types/deferred.php
+++ b/tests/types/deferred.php
@@ -1,0 +1,12 @@
+<?php
+
+use React\Promise\Deferred;
+use function PHPStan\Testing\assertType;
+
+$deferredA = new Deferred();
+assertType('React\Promise\PromiseInterface<mixed>', $deferredA->promise());
+
+/** @var Deferred<int> $deferredB */
+$deferredB = new Deferred();
+$deferredB->resolve(42);
+assertType('React\Promise\PromiseInterface<int>', $deferredB->promise());

--- a/tests/types/race.php
+++ b/tests/types/race.php
@@ -1,0 +1,10 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+use function React\Promise\race;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<bool>', race([resolve(true), resolve(false)]));
+assertType('React\Promise\PromiseInterface<bool>', race([resolve(true), false]));
+assertType('React\Promise\PromiseInterface<bool|int>', race([true, time()]));
+assertType('React\Promise\PromiseInterface<bool|int>', race([resolve(true), resolve(time())]));

--- a/tests/types/reject.php
+++ b/tests/types/reject.php
@@ -1,0 +1,59 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Promise\reject;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException()));
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->then(null, null));
+// assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->then(function (): int {
+//     return 42;
+// }));
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->then(null, function (): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->then(null, function (): PromiseInterface {
+    return resolve(42);
+}));
+// assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->then(function (): bool {
+//     return true;
+// }, function (): int {
+//     return 42;
+// }));
+
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->catch(function (): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->catch(function (\UnexpectedValueException $e): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->catch(function (): PromiseInterface {
+    return resolve(42);
+}));
+
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->finally(function (): void { }));
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->finally(function (): never {
+    throw new \UnexpectedValueException();
+}));
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->finally(function (): PromiseInterface {
+    return reject(new \UnexpectedValueException());
+}));
+
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->otherwise(function (): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->otherwise(function (\UnexpectedValueException $e): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->otherwise(function (): PromiseInterface {
+    return resolve(42);
+}));
+
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->always(function (): void { }));
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->always(function (): never {
+    throw new \UnexpectedValueException();
+}));
+assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->always(function (): PromiseInterface {
+    return reject(new \UnexpectedValueException());
+}));

--- a/tests/types/resolve.php
+++ b/tests/types/resolve.php
@@ -1,0 +1,87 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Promise\reject;
+use function React\Promise\resolve;
+
+/**
+ * @return int|string
+ */
+function stringOrInt() {
+    return time() % 2 ? 'string' : time();
+};
+
+/**
+ * @return PromiseInterface<int|string>
+ */
+function stringOrIntPromise(): PromiseInterface {
+    return resolve(time() % 2 ? 'string' : time());
+};
+
+assertType('React\Promise\PromiseInterface<bool>', resolve(true));
+assertType('React\Promise\PromiseInterface<int|string>', resolve(stringOrInt()));
+assertType('React\Promise\PromiseInterface<int|string>', stringOrIntPromise());
+assertType('React\Promise\PromiseInterface<bool>', resolve(resolve(true)));
+
+assertType('React\Promise\PromiseInterface<bool>', resolve(true)->then(null, null));
+assertType('React\Promise\PromiseInterface<bool>', resolve(true)->then(function (bool $bool): bool {
+    return $bool;
+}));
+assertType('React\Promise\PromiseInterface<int>', resolve(true)->then(function (bool $value): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<int>', resolve(true)->then(function (bool $value): PromiseInterface {
+    return resolve(42);
+}));
+assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->then(function (bool $value): never {
+    throw new \RuntimeException();
+}));
+assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->then(null, function (\Throwable $e): int {
+    return 42;
+}));
+
+assertType('React\Promise\PromiseInterface<void>', resolve(true)->then(function (bool $bool): void { }));
+assertType('React\Promise\PromiseInterface<void>', resolve(false)->then(function (bool $bool): void { })->then(function (null $value) { }));
+
+$value = null;
+assertType('React\Promise\PromiseInterface<void>', resolve(true)->then(static function (bool $v) use (&$value): void {
+    $value = $v;
+}));
+assertType('bool|null', $value);
+
+assertType('React\Promise\PromiseInterface<bool>', resolve(true)->catch(function (\Throwable $e): never {
+    throw $e;
+}));
+assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->catch(function (\Throwable $e): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->catch(function (\Throwable $e): PromiseInterface {
+    return resolve(42);
+}));
+
+assertType('React\Promise\PromiseInterface<bool>', resolve(true)->finally(function (): void { }));
+// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->finally(function (): never {
+//     throw new \RuntimeException();
+// }));
+// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->finally(function (): PromiseInterface {
+//     return reject(new \RuntimeException());
+// }));
+
+assertType('React\Promise\PromiseInterface<bool>', resolve(true)->otherwise(function (\Throwable $e): never {
+    throw $e;
+}));
+assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->otherwise(function (\Throwable $e): int {
+    return 42;
+}));
+assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->otherwise(function (\Throwable $e): PromiseInterface {
+    return resolve(42);
+}));
+
+assertType('React\Promise\PromiseInterface<bool>', resolve(true)->always(function (): void { }));
+// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->always(function (): never {
+//     throw new \RuntimeException();
+// }));
+// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->always(function (): PromiseInterface {
+//     return reject(new \RuntimeException());
+// }));


### PR DESCRIPTION
Adds template annotations turning the `PromiseInterface` into a generic.

Variables `$p1` and `$p2` in the following code example both are `PromiseInterface<int|string>`.

```php
$f = function (): int|string {
    return time() % 2 ? 'string' : time();
};

/**
 * @return PromiseInterface<int|string>
 */
$fp = function (): PromiseInterface {
    return resolve(time() % 2 ? 'string' : time());
};

$p1 = resolve($f());
$p2 = $fp();
```

When calling `then` on `$p1` or `$p2`, PHPStan understand that function `$f1` is type hinting its parameter fine, but `$f2` will throw during runtime:

```php
$p2->then(static function (int|string $a) {});
$p2->then(static function (bool $a) {});
```

Builds on top of https://github.com/reactphp/promise/pull/246 and https://github.com/reactphp/promise/pull/188 and is a requirement for https://github.com/reactphp/async/pull/40