### PR TITLE
Report any unhandled promise rejections

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,7 @@ parameters:
     paths:
         - src/
         - tests/
+
+    fileExtensions:
+        - php
+        - phpt

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <testsuites>
         <testsuite name="Promise Test Suite">
             <directory>./tests/</directory>
+            <directory suffix=".phpt">./tests/</directory>
         </testsuite>
     </testsuites>
     <coverage>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -8,6 +8,7 @@
     <testsuites>
         <testsuite name="Promise Test Suite">
             <directory>./tests/</directory>
+            <directory suffix=".phpt">./tests/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/functions.php
+++ b/src/functions.php
@@ -100,7 +100,7 @@ function all(iterable $promisesOrValues): PromiseInterface
                 }
             );
 
-            if (!$continue) {
+            if (!$continue && !\is_array($promisesOrValues)) {
                 break;
             }
         }
@@ -136,7 +136,7 @@ function race(iterable $promisesOrValues): PromiseInterface
                 $continue = false;
             });
 
-            if (!$continue) {
+            if (!$continue && !\is_array($promisesOrValues)) {
                 break;
             }
         }
@@ -187,7 +187,7 @@ function any(iterable $promisesOrValues): PromiseInterface
                 }
             );
 
-            if (!$continue) {
+            if (!$continue && !\is_array($promisesOrValues)) {
                 break;
             }
         }

--- a/tests/DeferredTest.php
+++ b/tests/DeferredTest.php
@@ -54,9 +54,13 @@ class DeferredTest extends TestCase
         gc_collect_cycles();
         gc_collect_cycles(); // clear twice to avoid leftovers in PHP 7.4 with ext-xdebug and code coverage turned on
 
+        /** @var Deferred $deferred */
         $deferred = new Deferred(function () use (&$deferred) {
             assert($deferred instanceof Deferred);
         });
+
+        $deferred->promise()->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         $deferred->reject(new \Exception('foo'));
         unset($deferred);
 

--- a/tests/DeferredTestCancelNoopThenRejectShouldNotReportUnhandled.phpt
+++ b/tests/DeferredTestCancelNoopThenRejectShouldNotReportUnhandled.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Calling cancel() and then reject() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use React\Promise\Deferred;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$deferred = new Deferred();
+$deferred->promise()->cancel();
+$deferred->reject(new RuntimeException('foo'));
+
+echo 'void' . PHP_EOL;
+
+?>
+--EXPECT--
+void

--- a/tests/DeferredTestCancelThatRejectsShouldNotReportUnhandled.phpt
+++ b/tests/DeferredTestCancelThatRejectsShouldNotReportUnhandled.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Calling cancel() that rejects should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use React\Promise\Deferred;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$deferred = new Deferred(function () { throw new \RuntimeException('Cancelled'); });
+$deferred->promise()->cancel();
+
+echo 'void' . PHP_EOL;
+
+?>
+--EXPECT--
+void

--- a/tests/DeferredTestRejectShouldReportUnhandled.phpt
+++ b/tests/DeferredTestRejectShouldReportUnhandled.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Calling reject() without any handlers should report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use React\Promise\Deferred;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$deferred = new Deferred();
+$deferred->reject(new RuntimeException('foo'));
+
+?>
+--EXPECTF--
+Unhandled promise rejection with RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}

--- a/tests/DeferredTestRejectThenCancelShouldNotReportUnhandled.phpt
+++ b/tests/DeferredTestRejectThenCancelShouldNotReportUnhandled.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Calling reject() and then cancel() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use React\Promise\Deferred;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$deferred = new Deferred();
+$deferred->reject(new RuntimeException('foo'));
+$deferred->promise()->cancel();
+
+echo 'void' . PHP_EOL;
+
+?>
+--EXPECT--
+void

--- a/tests/FunctionAllTest.php
+++ b/tests/FunctionAllTest.php
@@ -106,7 +106,7 @@ class FunctionAllTest extends TestCase
             ->method('__invoke')
             ->with(self::identicalTo($exception2));
 
-        all([resolve(1), reject($exception2), resolve($exception3)])
+        all([resolve(1), reject($exception2), reject($exception3)])
             ->then($this->expectCallableNever(), $mock);
     }
 

--- a/tests/FunctionAllTestRejectedShouldReportUnhandled.phpt
+++ b/tests/FunctionAllTestRejectedShouldReportUnhandled.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Calling all() with rejected promises should report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\all;
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+all([
+    reject(new RuntimeException('foo')),
+    reject(new RuntimeException('bar'))
+]);
+
+?>
+--EXPECTF--
+Unhandled promise rejection with RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}

--- a/tests/FunctionAllTestRejectedThenMatchingThatReturnsShouldNotReportUnhandled.phpt
+++ b/tests/FunctionAllTestRejectedThenMatchingThatReturnsShouldNotReportUnhandled.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Calling all() and then then() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\all;
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+all([
+    reject(new RuntimeException('foo')),
+    reject(new RuntimeException('bar'))
+])->then(null, function (\Throwable $e) {
+    echo 'Handled ' . get_class($e) . ': ' . $e->getMessage() . PHP_EOL;
+});
+
+?>
+--EXPECT--
+Handled RuntimeException: foo

--- a/tests/FunctionAnyTestRejectedShouldReportUnhandled.phpt
+++ b/tests/FunctionAnyTestRejectedShouldReportUnhandled.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Calling any() with rejected promises should report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\any;
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+any([
+    reject(new RuntimeException('foo')),
+    reject(new RuntimeException('bar'))
+]);
+
+?>
+--EXPECTF--
+Unhandled promise rejection with React\Promise\Exception\CompositeException: All promises rejected. in %s:%d
+Stack trace:
+#0 %s/src/Promise.php(%d): React\Promise\{closure}(%S)
+#1 %s/src/Promise.php(%d): React\Promise\Promise->call(%S)
+#2 %s/src/functions.php(%d): React\Promise\Promise->__construct(%S)
+#3 %s(%d): React\Promise\any(%S)
+#4 %A{main}
+

--- a/tests/FunctionAnyTestRejectedThenMatchingThatReturnsShouldNotReportUnhandled.phpt
+++ b/tests/FunctionAnyTestRejectedThenMatchingThatReturnsShouldNotReportUnhandled.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Calling any() and then then() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\any;
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+any([
+    reject(new RuntimeException('foo')),
+    reject(new RuntimeException('bar'))
+])->then(null, function (\Throwable $e) {
+    echo 'Handled ' . get_class($e) . ': ' . $e->getMessage() . PHP_EOL;
+});
+
+?>
+--EXPECT--
+Handled React\Promise\Exception\CompositeException: All promises rejected.

--- a/tests/FunctionRaceTestRejectedShouldReportUnhandled.phpt
+++ b/tests/FunctionRaceTestRejectedShouldReportUnhandled.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Calling race() with rejected promises should report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\race;
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+race([
+    reject(new RuntimeException('foo')),
+    reject(new RuntimeException('bar'))
+]);
+
+?>
+--EXPECTF--
+Unhandled promise rejection with RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}

--- a/tests/FunctionRaceTestRejectedThenMatchingThatReturnsShouldNotReportUnhandled.phpt
+++ b/tests/FunctionRaceTestRejectedThenMatchingThatReturnsShouldNotReportUnhandled.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Calling race() and then then() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\race;
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+race([
+    reject(new RuntimeException('foo')),
+    reject(new RuntimeException('bar'))
+])->then(null, function (\Throwable $e) {
+    echo 'Handled ' . get_class($e) . ': ' . $e->getMessage() . PHP_EOL;
+});
+
+?>
+--EXPECT--
+Handled RuntimeException: foo

--- a/tests/FunctionRejectTestCancelShouldNotReportUnhandled.phpt
+++ b/tests/FunctionRejectTestCancelShouldNotReportUnhandled.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Calling reject() and then cancel() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->cancel();
+
+echo 'void' . PHP_EOL;
+
+?>
+--EXPECT--
+void

--- a/tests/FunctionRejectTestCatchMatchingShouldNotReportUnhandled.phpt
+++ b/tests/FunctionRejectTestCatchMatchingShouldNotReportUnhandled.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Calling reject() and then catch() with matching type should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->catch(function (RuntimeException $e): void {
+    echo 'Handled ' . get_class($e) . ': ' . $e->getMessage() . PHP_EOL;
+});
+
+?>
+--EXPECT--
+Handled RuntimeException: foo

--- a/tests/FunctionRejectTestCatchMismatchShouldReportUnhandled.phpt
+++ b/tests/FunctionRejectTestCatchMismatchShouldReportUnhandled.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Calling reject() and then catch() with mismatched type should report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->catch(function (UnexpectedValueException $unexpected): void {
+    echo 'This will never be shown because the types do not match' . PHP_EOL;
+});
+
+?>
+--EXPECTF--
+Unhandled promise rejection with RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}

--- a/tests/FunctionRejectTestFinallyThatReturnsShouldReportUnhandled.phpt
+++ b/tests/FunctionRejectTestFinallyThatReturnsShouldReportUnhandled.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Calling reject() and then finally() should call handler and report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->finally(function (): void {
+    echo 'Foo' . PHP_EOL;
+});
+
+?>
+--EXPECTF--
+Foo
+Unhandled promise rejection with RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}

--- a/tests/FunctionRejectTestFinallyThatThrowsNewExceptionShouldReportUnhandledForNewExceptionOnly.phpt
+++ b/tests/FunctionRejectTestFinallyThatThrowsNewExceptionShouldReportUnhandledForNewExceptionOnly.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Calling reject() and then finally() should call handler and report unhandled rejection for new exception from handler
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->finally(function (): void {
+    throw new \RuntimeException('Finally!');
+});
+
+?>
+--EXPECTF--
+Unhandled promise rejection with RuntimeException: Finally! in %s:%d
+Stack trace:
+#0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
+#1 %s/src/Internal/RejectedPromise.php(%d): React\Promise\Internal\RejectedPromise->React\Promise\Internal\{closure}(%S)
+#2 %s/src/Internal/RejectedPromise.php(%d): React\Promise\Internal\RejectedPromise->then(%S)
+#3 %s(%d): React\Promise\Internal\RejectedPromise->finally(%S)
+#4 %A{main}

--- a/tests/FunctionRejectTestShouldReportUnhandled.phpt
+++ b/tests/FunctionRejectTestShouldReportUnhandled.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Calling reject() without any handlers should report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'));
+
+?>
+--EXPECTF--
+Unhandled promise rejection with RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}

--- a/tests/FunctionRejectTestThenMatchingThatReturnsShouldNotReportUnhandled.phpt
+++ b/tests/FunctionRejectTestThenMatchingThatReturnsShouldNotReportUnhandled.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Calling reject() and then then() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->then(null, function (\Throwable $e) {
+    echo 'Handled ' . get_class($e) . ': ' . $e->getMessage() . PHP_EOL;
+});
+
+?>
+--EXPECT--
+Handled RuntimeException: foo

--- a/tests/FunctionRejectTestThenMatchingThatThrowsNewExceptionShouldReportUnhandledRejectionForNewExceptionOnly.phpt
+++ b/tests/FunctionRejectTestThenMatchingThatThrowsNewExceptionShouldReportUnhandledRejectionForNewExceptionOnly.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Calling reject() and then then() should report unhandled rejection for new exception from handler
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->then(null, function () {
+    throw new \RuntimeException('bar');
+});
+
+?>
+--EXPECTF--
+Unhandled promise rejection with RuntimeException: bar in %s:%d
+Stack trace:
+#0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
+#1 %s(%d): React\Promise\Internal\RejectedPromise->then(%S)
+#2 %A{main}

--- a/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp7.phpt
+++ b/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp7.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Calling reject() and then then() with invalid type should report unhandled rejection for TypeError
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die("Skipped: PHP 7 only."); ?>
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueException $unexpected): void {
+    echo 'This will never be shown because the types do not match' . PHP_EOL;
+});
+
+?>
+--EXPECTF--
+Unhandled promise rejection with TypeError: Argument 1 passed to {closure}() must be an instance of UnexpectedValueException, instance of RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d in %s:%d
+Stack trace:
+#0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
+#1 %s(%d): React\Promise\Internal\RejectedPromise->then(%S)
+#2 %A{main}

--- a/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
+++ b/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Calling reject() and then then() with invalid type should report unhandled rejection for TypeError
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80000) die("Skipped: PHP 8+ only."); ?>
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueException $unexpected): void {
+    echo 'This will never be shown because the types do not match' . PHP_EOL;
+});
+
+?>
+--EXPECTF--
+Unhandled promise rejection with TypeError: {closure}(): Argument #1 ($unexpected) must be of type UnexpectedValueException, RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d in %s:%d
+Stack trace:
+#0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
+#1 %s(%d): React\Promise\Internal\RejectedPromise->then(%S)
+#2 %A{main}

--- a/tests/FunctionResolveTest.php
+++ b/tests/FunctionResolveTest.php
@@ -128,6 +128,10 @@ class FunctionResolveTest extends TestCase
     /** @test */
     public function shouldSupportVeryDeepNestedPromises(): void
     {
+        if (PHP_VERSION_ID < 70200 && ini_get('xdebug.max_nesting_level') !== false) {
+            $this->markTestSkipped('Skip unhandled rejection on legacy PHP 7.1');
+        }
+
         $deferreds = [];
 
         for ($i = 0; $i < 150; $i++) {

--- a/tests/FunctionResolveTestThenShouldNotReportUnhandled.phpt
+++ b/tests/FunctionResolveTestThenShouldNotReportUnhandled.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Calling resolve() and then then() should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\resolve;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+resolve(42)->then('var_dump');
+
+?>
+--EXPECT--
+int(42)

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -66,6 +66,9 @@ class PromiseTest extends TestCase
         $promise = new Promise(function () {
             throw new \Exception('foo');
         });
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -78,6 +81,9 @@ class PromiseTest extends TestCase
         $promise = new Promise(function ($resolve, $reject) {
             $reject(new \Exception('foo'));
         });
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -116,6 +122,9 @@ class PromiseTest extends TestCase
         $promise = new Promise(function ($resolve, $reject) {
             throw new \Exception('foo');
         });
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -137,6 +146,7 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerWithReferenceThrowsException(): void
     {
         gc_collect_cycles();
+        /** @var Promise $promise */
         $promise = new Promise(function () {}, function () use (&$promise) {
             assert($promise instanceof Promise);
             throw new \Exception('foo');
@@ -155,10 +165,14 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfResolverWithReferenceThrowsException(): void
     {
         gc_collect_cycles();
+        /** @var Promise $promise */
         $promise = new Promise(function () use (&$promise) {
             assert($promise instanceof Promise);
             throw new \Exception('foo');
         });
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -172,11 +186,15 @@ class PromiseTest extends TestCase
     public function shouldRejectWithoutCreatingGarbageCyclesIfCancellerHoldsReferenceAndResolverThrowsException(): void
     {
         gc_collect_cycles();
+        /** @var Promise $promise */
         $promise = new Promise(function () {
             throw new \Exception('foo');
         }, function () use (&$promise) {
             assert($promise instanceof Promise);
         });
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         $this->assertSame(0, gc_collect_cycles());
@@ -260,6 +278,9 @@ class PromiseTest extends TestCase
         $promise = new Promise(function () {
             throw new Exception('foo');
         });
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         self::assertSame(0, gc_collect_cycles());

--- a/tests/PromiseTest/PromiseRejectedTestTrait.php
+++ b/tests/PromiseTest/PromiseRejectedTestTrait.php
@@ -261,7 +261,7 @@ trait PromiseRejectedTestTrait
         $adapter->promise()
             ->catch(function (InvalidArgumentException $reason) use ($mock) {
                 $mock($reason);
-            });
+            })->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
     }
 
     /** @test */
@@ -461,7 +461,7 @@ trait PromiseRejectedTestTrait
         $adapter->promise()
             ->otherwise(function (InvalidArgumentException $reason) use ($mock) {
                 $mock($reason);
-            });
+            })->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
     }
 
     /**

--- a/tests/PromiseTest/PromiseSettledTestTrait.php
+++ b/tests/PromiseTest/PromiseSettledTestTrait.php
@@ -2,6 +2,7 @@
 
 namespace React\Promise\PromiseTest;
 
+use React\Promise\Internal\RejectedPromise;
 use React\Promise\PromiseAdapter\PromiseAdapterInterface;
 use React\Promise\PromiseInterface;
 
@@ -16,6 +17,10 @@ trait PromiseSettledTestTrait
 
         $adapter->settle(null);
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->then());
+
+        if ($adapter->promise() instanceof RejectedPromise) {
+            $adapter->promise()->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+        }
     }
 
     /** @test */
@@ -25,6 +30,10 @@ trait PromiseSettledTestTrait
 
         $adapter->settle(null);
         self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->then(null, null));
+
+        if ($adapter->promise() instanceof RejectedPromise) {
+            $adapter->promise()->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+        }
     }
 
     /** @test */
@@ -43,7 +52,11 @@ trait PromiseSettledTestTrait
         $adapter = $this->getPromiseTestAdapter();
 
         $adapter->settle(null);
-        self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->finally(function () {}));
+        self::assertInstanceOf(PromiseInterface::class, $promise = $adapter->promise()->finally(function () {}));
+
+        if ($promise instanceof RejectedPromise) {
+            $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+        }
     }
 
     /**
@@ -55,6 +68,10 @@ trait PromiseSettledTestTrait
         $adapter = $this->getPromiseTestAdapter();
 
         $adapter->settle(null);
-        self::assertInstanceOf(PromiseInterface::class, $adapter->promise()->always(function () {}));
+        self::assertInstanceOf(PromiseInterface::class, $promise = $adapter->promise()->always(function () {}));
+
+        if ($promise instanceof RejectedPromise) {
+            $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+        }
     }
 }

--- a/tests/PromiseTestCancelThatRejectsAfterwardsShouldNotReportUnhandled.phpt
+++ b/tests/PromiseTestCancelThatRejectsAfterwardsShouldNotReportUnhandled.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Calling cancel() that rejects afterwards should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use React\Promise\Promise;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/** @var callable(Throwable):void $reject */
+$promise = new Promise(function () { }, function ($_, callable $callback) use (&$reject) { $reject = $callback; });
+$promise->cancel();
+
+assert($reject instanceof \Closure);
+$reject(new \RuntimeException('Cancelled'));
+
+echo 'void' . PHP_EOL;
+
+?>
+--EXPECT--
+void

--- a/tests/PromiseTestCancelThatRejectsShouldNotReportUnhandled.phpt
+++ b/tests/PromiseTestCancelThatRejectsShouldNotReportUnhandled.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Calling cancel() that rejects should not report unhandled rejection
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use React\Promise\Promise;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$promise = new Promise(function () { }, function () { throw new \RuntimeException('Cancelled'); });
+$promise->cancel();
+
+echo 'void' . PHP_EOL;
+
+?>
+--EXPECT--
+void


### PR DESCRIPTION
This changeset adds new functionality to make sure we report any unhandled promise rejections. If you remove the last reference to a rejected promise that has not been handled, it will now report an unhandled promise rejection:

```php
function incorrect(): int
{
     $promise = React\Promise\reject(new RuntimeException('Request failed'));

     // Commented out: No rejection handler registered here.
     // $promise->then(null, function (\Throwable $e): void { /* ignore */ });

     // Returning from a function will remove all local variable references, hence why
     // this will report an unhandled promise rejection here.
     return 42;
}

// Calling this function will log an error message plus its stack trace:
// Unhandled promise rejection with RuntimeException: Request failed in example.php:10
incorrect();
```

The old behavior was to simply hide any unhandled rejections which has been a constant source of frustration for newcomers and for larger applications alike (see #87 and dozens of referenced tickets). The updated implementation provides a better default behavior that is more in line with how exceptions in PHP are also reported by default and significantly improves error reporting.

Any unhandled promise rejections will currently always be written to PHP's default error log location (`STDERR` for cli, Apache error log, etc.). Once this PR is merged, I've prepared a follow-up PR to provide a custom log handler function to write to custom log locations similar to how `set_exception_handler()` and `set_error_handler()` work.

I've also tested this branch against all ReactPHP components and dozens of downstream dependencies. Most projects do indeed execute just fine these changes. However, it is quite common for unhandled promise rejections to occur in their test suites. I've prepared a number of PRs for downstream components that I would file in the next couple of days to address this.

This PR comes with a sophisticated test suite and does not otherwise affect the existing behavior as verified by the existing test suite, so this should be safe to apply. Combined, you're looking a several days worth of work, enjoy! 🎉

Resolves / closes #87
Supersedes / closes #170
Supersedes / closes #222
Builds on top of #246, #240 and others