### PR TITLE
Update PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">=7.1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.20 || 1.4.10",
+        "phpstan/phpstan": "1.10.34 || 1.4.10",
         "phpunit/phpunit": "^9.5 || ^7.5"
     },
     "autoload": {

--- a/tests/types/reject.php
+++ b/tests/types/reject.php
@@ -5,9 +5,9 @@ use function PHPStan\Testing\assertType;
 use function React\Promise\reject;
 use function React\Promise\resolve;
 
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException()));
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->then(null, null));
-// assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->then(function (): int {
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException()));
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->then(null, null));
+// assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->then(function (): int {
 //     return 42;
 // }));
 assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())->then(null, function (): int {
@@ -32,11 +32,11 @@ assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())
     return resolve(42);
 }));
 
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->finally(function (): void { }));
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->finally(function (): never {
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->finally(function (): void { }));
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->finally(function (): never {
     throw new \UnexpectedValueException();
 }));
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->finally(function (): PromiseInterface {
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->finally(function (): PromiseInterface {
     return reject(new \UnexpectedValueException());
 }));
 
@@ -50,10 +50,10 @@ assertType('React\Promise\PromiseInterface<int>', reject(new RuntimeException())
     return resolve(42);
 }));
 
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->always(function (): void { }));
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->always(function (): never {
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->always(function (): void { }));
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->always(function (): never {
     throw new \UnexpectedValueException();
 }));
-assertType('React\Promise\PromiseInterface<*NEVER*>', reject(new RuntimeException())->always(function (): PromiseInterface {
+assertType('React\Promise\PromiseInterface<never>', reject(new RuntimeException())->always(function (): PromiseInterface {
     return reject(new \UnexpectedValueException());
 }));

--- a/tests/types/resolve.php
+++ b/tests/types/resolve.php
@@ -34,7 +34,7 @@ assertType('React\Promise\PromiseInterface<int>', resolve(true)->then(function (
 assertType('React\Promise\PromiseInterface<int>', resolve(true)->then(function (bool $value): PromiseInterface {
     return resolve(42);
 }));
-assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->then(function (bool $value): never {
+assertType('React\Promise\PromiseInterface<never>', resolve(true)->then(function (bool $value): never {
     throw new \RuntimeException();
 }));
 assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->then(null, function (\Throwable $e): int {
@@ -61,10 +61,10 @@ assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->catch(func
 }));
 
 assertType('React\Promise\PromiseInterface<bool>', resolve(true)->finally(function (): void { }));
-// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->finally(function (): never {
+// assertType('React\Promise\PromiseInterface<never>', resolve(true)->finally(function (): never {
 //     throw new \RuntimeException();
 // }));
-// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->finally(function (): PromiseInterface {
+// assertType('React\Promise\PromiseInterface<never>', resolve(true)->finally(function (): PromiseInterface {
 //     return reject(new \RuntimeException());
 // }));
 
@@ -79,9 +79,9 @@ assertType('React\Promise\PromiseInterface<bool|int>', resolve(true)->otherwise(
 }));
 
 assertType('React\Promise\PromiseInterface<bool>', resolve(true)->always(function (): void { }));
-// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->always(function (): never {
+// assertType('React\Promise\PromiseInterface<never>', resolve(true)->always(function (): never {
 //     throw new \RuntimeException();
 // }));
-// assertType('React\Promise\PromiseInterface<*NEVER*>', resolve(true)->always(function (): PromiseInterface {
+// assertType('React\Promise\PromiseInterface<never>', resolve(true)->always(function (): PromiseInterface {
 //     return reject(new \RuntimeException());
 // }));


### PR DESCRIPTION
PHPStan 1.10.31 introduces NonAcceptingNeverType (https://github.com/phpstan/phpstan/issues/6485, https://github.com/phpstan/phpstan/issues/9133) that ensures that a literal `never` type in the code does not accept any other type except `never`.

As a side-effect of this change a type description or an error message about this changed from `*NEVER*` to `never`. I'm sending an update to your test suite because of this :)