### PR TITLE
Describe all callable arguments with types for `Promise` and `Deferred`

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ $promise = new React\Promise\Promise($resolver, $canceller);
 ```
 
 The promise constructor receives a resolver function and an optional canceller
-function which both will be called with 3 arguments:
+function which both will be called with two arguments:
 
   * `$resolve($value)` - Primary function that seals the fate of the
     returned promise. Accepts either a non-promise value, or another promise.

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -12,12 +12,15 @@ final class Deferred
      */
     private $promise;
 
-    /** @var callable */
+    /** @var callable(T):void */
     private $resolveCallback;
 
-    /** @var callable */
+    /** @var callable(\Throwable):void */
     private $rejectCallback;
 
+    /**
+     * @param (callable(callable(T):void,callable(\Throwable):void):void)|null $canceller
+     */
     public function __construct(callable $canceller = null)
     {
         $this->promise = new Promise(function ($resolve, $reject): void {

--- a/src/functions.php
+++ b/src/functions.php
@@ -35,7 +35,8 @@ function resolve($promiseOrValue): PromiseInterface
             assert(\is_callable($canceller));
         }
 
-        return new Promise(function ($resolve, $reject) use ($promiseOrValue): void {
+        /** @var Promise<T> */
+        return new Promise(function (callable $resolve, callable $reject) use ($promiseOrValue): void {
             $promiseOrValue->then($resolve, $reject);
         }, $canceller);
     }
@@ -77,7 +78,8 @@ function all(iterable $promisesOrValues): PromiseInterface
 {
     $cancellationQueue = new Internal\CancellationQueue();
 
-    return new Promise(function ($resolve, $reject) use ($promisesOrValues, $cancellationQueue): void {
+    /** @var Promise<array<T>> */
+    return new Promise(function (callable $resolve, callable $reject) use ($promisesOrValues, $cancellationQueue): void {
         $toResolve = 0;
         /** @var bool */
         $continue  = true;
@@ -129,6 +131,7 @@ function race(iterable $promisesOrValues): PromiseInterface
 {
     $cancellationQueue = new Internal\CancellationQueue();
 
+    /** @var Promise<T> */
     return new Promise(function (callable $resolve, callable $reject) use ($promisesOrValues, $cancellationQueue): void {
         $continue = true;
 
@@ -165,7 +168,8 @@ function any(iterable $promisesOrValues): PromiseInterface
 {
     $cancellationQueue = new Internal\CancellationQueue();
 
-    return new Promise(function ($resolve, $reject) use ($promisesOrValues, $cancellationQueue): void {
+    /** @var Promise<T> */
+    return new Promise(function (callable $resolve, callable $reject) use ($promisesOrValues, $cancellationQueue): void {
         $toReject = 0;
         $continue = true;
         $reasons  = [];

--- a/tests/Internal/CancellationQueueTest.php
+++ b/tests/Internal/CancellationQueueTest.php
@@ -101,6 +101,7 @@ class CancellationQueueTest extends TestCase
      */
     private function getCancellableDeferred(): Deferred
     {
+        /** @var Deferred<never> */
         return new Deferred($this->expectCallableOnce());
     }
 }

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -19,10 +19,13 @@ class PromiseTest extends TestCase
     {
         $resolveCallback = $rejectCallback = null;
 
-        $promise = new Promise(function ($resolve, $reject) use (&$resolveCallback, &$rejectCallback) {
+        $promise = new Promise(function (callable $resolve, callable $reject) use (&$resolveCallback, &$rejectCallback): void {
             $resolveCallback = $resolve;
             $rejectCallback  = $reject;
         }, $canceller);
+
+        assert(is_callable($resolveCallback));
+        assert(is_callable($rejectCallback));
 
         return new CallbackPromiseAdapter([
             'promise' => function () use ($promise) {

--- a/tests/types/deferred.php
+++ b/tests/types/deferred.php
@@ -10,3 +10,40 @@ assertType('React\Promise\PromiseInterface<mixed>', $deferredA->promise());
 $deferredB = new Deferred();
 $deferredB->resolve(42);
 assertType('React\Promise\PromiseInterface<int>', $deferredB->promise());
+
+// $deferred = new Deferred();
+// $deferred->resolve(42);
+// assertType('React\Promise\Deferred<int>', $deferred);
+
+// $deferred = new Deferred();
+// $deferred->resolve(true);
+// $deferred->resolve('ignored');
+// assertType('React\Promise\Deferred<bool>', $deferred);
+
+// $deferred = new Deferred();
+// $deferred->reject(new \RuntimeException());
+// assertType('React\Promise\Deferred<never>', $deferred);
+
+// invalid number of arguments passed to $canceller
+/** @phpstan-ignore-next-line */
+$deferred = new Deferred(function ($a, $b, $c) { });
+assertType('React\Promise\Deferred<mixed>', $deferred);
+
+// invalid types for arguments of $canceller
+/** @phpstan-ignore-next-line */
+$deferred = new Deferred(function (int $a, string $b) { });
+assertType('React\Promise\Deferred<mixed>', $deferred);
+
+// invalid number of arguments passed to $resolve
+$deferred = new Deferred(function (callable $resolve) {
+    /** @phpstan-ignore-next-line */
+    $resolve();
+});
+assertType('React\Promise\Deferred<mixed>', $deferred);
+
+// invalid type passed to $reject
+$deferred = new Deferred(function (callable $resolve, callable $reject) {
+    /** @phpstan-ignore-next-line */
+    $reject(2);
+});
+assertType('React\Promise\Deferred<mixed>', $deferred);

--- a/tests/types/promise.php
+++ b/tests/types/promise.php
@@ -1,0 +1,91 @@
+<?php
+
+use React\Promise\Promise;
+use function PHPStan\Testing\assertType;
+
+// $promise = new Promise(function (): void { });
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// $promise = new Promise(function (callable $resolve): void {
+//     $resolve(42);
+// });
+// assertType('React\Promise\PromiseInterface<int>', $promise);
+
+// $promise = new Promise(function (callable $resolve): void {
+//     $resolve(true);
+//     $resolve('ignored');
+// });
+// assertType('React\Promise\PromiseInterface<bool>', $promise);
+
+// $promise = new Promise(function (callable $resolve, callable $reject): void {
+//     $reject(new \RuntimeException());
+// });
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// $promise = new Promise(function (): never {
+//     throw new \RuntimeException();
+// });
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid number of arguments for $resolver
+/** @phpstan-ignore-next-line */
+$promise = new Promise(function ($a, $b, $c) { });
+assert($promise instanceof Promise);
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid types for arguments of $resolver
+/** @phpstan-ignore-next-line */
+$promise = new Promise(function (int $a, string $b) { });
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid number of arguments passed to $resolve
+$promise = new Promise(function (callable $resolve) {
+    /** @phpstan-ignore-next-line */
+    $resolve();
+});
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid number of arguments passed to $reject
+$promise = new Promise(function (callable $resolve, callable $reject) {
+    /** @phpstan-ignore-next-line */
+    $reject();
+});
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid type passed to $reject
+$promise = new Promise(function (callable $resolve, callable $reject) {
+    /** @phpstan-ignore-next-line */
+    $reject(2);
+});
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid number of arguments for $canceller
+/** @phpstan-ignore-next-line */
+$promise = new Promise(function () { }, function ($a, $b, $c) { });
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid types for arguments of $canceller
+/** @phpstan-ignore-next-line */
+$promise = new Promise(function () { }, function (int $a, string $b) { });
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid number of arguments passed to $resolve
+$promise = new Promise(function () { }, function (callable $resolve) {
+    /** @phpstan-ignore-next-line */
+    $resolve();
+});
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid number of arguments passed to $reject
+$promise = new Promise(function () { }, function (callable $resolve, callable $reject) {
+    /** @phpstan-ignore-next-line */
+    $reject();
+});
+// assertType('React\Promise\PromiseInterface<never>', $promise);
+
+// invalid type passed to $reject
+$promise = new Promise(function() { }, function (callable $resolve, callable $reject) {
+    /** @phpstan-ignore-next-line */
+    $reject(2);
+});
+// assertType('React\Promise\PromiseInterface<never>', $promise);


### PR DESCRIPTION
This changeset describes all callable arguments with types for `Promise` and `Deferred`. In particular, this makes it easier to detect incorrect usage using static analysis, such as when omitting required arguments as discussed in #213 and #138.

Builds on top of #247, #246 and others
Closes #252