### PR TITLE
[1.x] Run tests on PHP 8.3 and update test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.3
+          - 8.2
+          - 8.1
+          - 8.0
           - 7.4
           - 7.3
           - 7.2
@@ -21,7 +25,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -38,7 +42,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
       - name: Run hhvm composer.phar install
         uses: docker://hhvm/hhvm:3.30-lts-latest

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,19 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
     },
     "autoload": {
         "psr-4": { 
-            "React\\Promise\\": "src/React/Promise/" 
+            "React\\Promise\\": "src/React/Promise/"
         },
-        "files": ["src/React/Promise/functions_include.php"]
+        "files": [
+            "src/React/Promise/functions_include.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
-            "React\\Tests\\Promise\\": "tests/React/Promise/" 
+            "React\\Tests\\Promise\\": "tests/React/Promise/"
         }
     },
     "extra": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.5+ -->
+<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
          colors="true"
@@ -20,7 +20,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
-        <!-- <ini name="zend.assertions=1" value="1" /> -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
         <ini name="assert.active" value="1" />
         <ini name="assert.exception" value="1" />
         <ini name="assert.bail" value="0" />

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with old format before PHPUnit 9 -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="vendor/autoload.php"
@@ -18,7 +18,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
-        <!-- <ini name="zend.assertions=1" value="1" /> -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
         <ini name="assert.active" value="1" />
         <ini name="assert.exception" value="1" />
         <ini name="assert.bail" value="0" />

--- a/tests/React/Promise/ErrorCollector.php
+++ b/tests/React/Promise/ErrorCollector.php
@@ -10,8 +10,8 @@ class ErrorCollector
     {
         $errors = array();
 
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) use (&$errors) {
-            $errors[] = compact('errno', 'errstr', 'errfile', 'errline', 'errcontext');
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$errors) {
+            $errors[] = compact('errno', 'errstr', 'errfile', 'errline');
         });
 
         $this->errors = &$errors;


### PR DESCRIPTION
This changeset backports #256 from `2.x` to `1.x` (see also #255 for same changes in `3.x`). 

Builds on top of #242 and https://github.com/reactphp/stream/pull/172