### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -21,7 +21,7 @@ final class Deferred
     /**
      * @param (callable(callable(T):void,callable(\Throwable):void):void)|null $canceller
      */
-    public function __construct(callable $canceller = null)
+    public function __construct(?callable $canceller = null)
     {
         $this->promise = new Promise(function ($resolve, $reject): void {
             $this->resolveCallback = $resolve;

--- a/src/Internal/FulfilledPromise.php
+++ b/src/Internal/FulfilledPromise.php
@@ -34,7 +34,7 @@ final class FulfilledPromise implements PromiseInterface
      * @param ?(callable((T is void ? null : T)): (PromiseInterface<TFulfilled>|TFulfilled)) $onFulfilled
      * @return PromiseInterface<($onFulfilled is null ? T : TFulfilled)>
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null): PromiseInterface
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface
     {
         if (null === $onFulfilled) {
             return $this;

--- a/src/Internal/RejectedPromise.php
+++ b/src/Internal/RejectedPromise.php
@@ -61,7 +61,7 @@ final class RejectedPromise implements PromiseInterface
      * @param ?(callable(\Throwable): (PromiseInterface<TRejected>|TRejected)) $onRejected
      * @return PromiseInterface<($onRejected is null ? never : TRejected)>
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null): PromiseInterface
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface
     {
         if (null === $onRejected) {
             return $this;

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -29,7 +29,7 @@ final class Promise implements PromiseInterface
      * @param callable(callable(T):void,callable(\Throwable):void):void $resolver
      * @param (callable(callable(T):void,callable(\Throwable):void):void)|null $canceller
      */
-    public function __construct(callable $resolver, callable $canceller = null)
+    public function __construct(callable $resolver, ?callable $canceller = null)
     {
         $this->canceller = $canceller;
 
@@ -41,7 +41,7 @@ final class Promise implements PromiseInterface
         $this->call($cb);
     }
 
-    public function then(callable $onFulfilled = null, callable $onRejected = null): PromiseInterface
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface
     {
         if (null !== $this->result) {
             return $this->result->then($onFulfilled, $onRejected);
@@ -166,7 +166,7 @@ final class Promise implements PromiseInterface
         return $this->finally($onFulfilledOrRejected);
     }
 
-    private function resolver(callable $onFulfilled = null, callable $onRejected = null): callable
+    private function resolver(?callable $onFulfilled = null, ?callable $onRejected = null): callable
     {
         return function (callable $resolve, callable $reject) use ($onFulfilled, $onRejected): void {
             $this->handlers[] = static function (PromiseInterface $promise) use ($onFulfilled, $onRejected, $resolve, $reject): void {

--- a/tests/DeferredTest.php
+++ b/tests/DeferredTest.php
@@ -14,7 +14,7 @@ class DeferredTest extends TestCase
     /**
      * @return CallbackPromiseAdapter<T>
      */
-    public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
+    public function getPromiseTestAdapter(?callable $canceller = null): CallbackPromiseAdapter
     {
         $d = new Deferred($canceller);
 

--- a/tests/Internal/FulfilledPromiseTest.php
+++ b/tests/Internal/FulfilledPromiseTest.php
@@ -20,7 +20,7 @@ class FulfilledPromiseTest extends TestCase
     /**
      * @return CallbackPromiseAdapter<T>
      */
-    public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
+    public function getPromiseTestAdapter(?callable $canceller = null): CallbackPromiseAdapter
     {
         /** @var ?FulfilledPromise<T> */
         $promise = null;

--- a/tests/Internal/RejectedPromiseTest.php
+++ b/tests/Internal/RejectedPromiseTest.php
@@ -17,7 +17,7 @@ class RejectedPromiseTest extends TestCase
     /**
      * @return CallbackPromiseAdapter<never>
      */
-    public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
+    public function getPromiseTestAdapter(?callable $canceller = null): CallbackPromiseAdapter
     {
         /** @var ?RejectedPromise */
         $promise = null;

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -15,7 +15,7 @@ class PromiseTest extends TestCase
     /**
      * @return CallbackPromiseAdapter<T>
      */
-    public function getPromiseTestAdapter(callable $canceller = null): CallbackPromiseAdapter
+    public function getPromiseTestAdapter(?callable $canceller = null): CallbackPromiseAdapter
     {
         $resolveCallback = $rejectCallback = null;
 

--- a/tests/PromiseTest/CancelTestTrait.php
+++ b/tests/PromiseTest/CancelTestTrait.php
@@ -8,7 +8,7 @@ use React\Promise\PromiseAdapter\PromiseAdapterInterface;
 
 trait CancelTestTrait
 {
-    abstract public function getPromiseTestAdapter(callable $canceller = null): PromiseAdapterInterface;
+    abstract public function getPromiseTestAdapter(?callable $canceller = null): PromiseAdapterInterface;
 
     /** @test */
     public function cancelShouldCallCancellerWithResolverArguments(): void

--- a/tests/PromiseTest/PromiseFulfilledTestTrait.php
+++ b/tests/PromiseTest/PromiseFulfilledTestTrait.php
@@ -11,7 +11,7 @@ use function React\Promise\resolve;
 
 trait PromiseFulfilledTestTrait
 {
-    abstract public function getPromiseTestAdapter(callable $canceller = null): PromiseAdapterInterface;
+    abstract public function getPromiseTestAdapter(?callable $canceller = null): PromiseAdapterInterface;
 
     /** @test */
     public function fulfilledPromiseShouldBeImmutable(): void

--- a/tests/PromiseTest/PromisePendingTestTrait.php
+++ b/tests/PromiseTest/PromisePendingTestTrait.php
@@ -7,7 +7,7 @@ use React\Promise\PromiseInterface;
 
 trait PromisePendingTestTrait
 {
-    abstract public function getPromiseTestAdapter(callable $canceller = null): PromiseAdapterInterface;
+    abstract public function getPromiseTestAdapter(?callable $canceller = null): PromiseAdapterInterface;
 
     /** @test */
     public function thenShouldReturnAPromiseForPendingPromise(): void

--- a/tests/PromiseTest/PromiseRejectedTestTrait.php
+++ b/tests/PromiseTest/PromiseRejectedTestTrait.php
@@ -11,7 +11,7 @@ use function React\Promise\resolve;
 
 trait PromiseRejectedTestTrait
 {
-    abstract public function getPromiseTestAdapter(callable $canceller = null): PromiseAdapterInterface;
+    abstract public function getPromiseTestAdapter(?callable $canceller = null): PromiseAdapterInterface;
 
     /** @test */
     public function rejectedPromiseShouldBeImmutable(): void

--- a/tests/PromiseTest/PromiseSettledTestTrait.php
+++ b/tests/PromiseTest/PromiseSettledTestTrait.php
@@ -8,7 +8,7 @@ use React\Promise\PromiseInterface;
 
 trait PromiseSettledTestTrait
 {
-    abstract public function getPromiseTestAdapter(callable $canceller = null): PromiseAdapterInterface;
+    abstract public function getPromiseTestAdapter(?callable $canceller = null): PromiseAdapterInterface;
 
     /** @test */
     public function thenShouldReturnAPromiseForSettledPromise(): void

--- a/tests/PromiseTest/RejectTestTrait.php
+++ b/tests/PromiseTest/RejectTestTrait.php
@@ -12,7 +12,7 @@ use function React\Promise\resolve;
 
 trait RejectTestTrait
 {
-    abstract public function getPromiseTestAdapter(callable $canceller = null): PromiseAdapterInterface;
+    abstract public function getPromiseTestAdapter(?callable $canceller = null): PromiseAdapterInterface;
 
     /** @test */
     public function rejectShouldRejectWithAnException(): void

--- a/tests/PromiseTest/ResolveTestTrait.php
+++ b/tests/PromiseTest/ResolveTestTrait.php
@@ -13,7 +13,7 @@ use function React\Promise\resolve;
 
 trait ResolveTestTrait
 {
-    abstract public function getPromiseTestAdapter(callable $canceller = null): PromiseAdapterInterface;
+    abstract public function getPromiseTestAdapter(?callable $canceller = null): PromiseAdapterInterface;
 
     /** @test */
     public function resolveShouldResolve(): void

--- a/tests/fixtures/SimpleFulfilledTestThenable.php
+++ b/tests/fixtures/SimpleFulfilledTestThenable.php
@@ -4,7 +4,7 @@ namespace React\Promise;
 
 class SimpleFulfilledTestThenable
 {
-    public function then(callable $onFulfilled = null, callable $onRejected = null): self
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): self
     {
         if ($onFulfilled) {
             $onFulfilled('foo');

--- a/tests/fixtures/SimpleTestCancellableThenable.php
+++ b/tests/fixtures/SimpleTestCancellableThenable.php
@@ -10,12 +10,12 @@ class SimpleTestCancellableThenable
     /** @var ?callable */
     public $onCancel;
 
-    public function __construct(callable $onCancel = null)
+    public function __construct(?callable $onCancel = null)
     {
         $this->onCancel = $onCancel;
     }
 
-    public function then(callable $onFulfilled = null, callable $onRejected = null): self
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): self
     {
         return new self();
     }


### PR DESCRIPTION
Fixes all issues that emits a deprecation notice on PHP 8.4.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)