### PR TITLE
Update test suite to improve PHP 8.4+ support

### DIFF
--- a/tests/FunctionAnyTestRejectedShouldReportUnhandled.phpt
+++ b/tests/FunctionAnyTestRejectedShouldReportUnhandled.phpt
@@ -20,7 +20,7 @@ any([
 --EXPECTF--
 Unhandled promise rejection with React\Promise\Exception\CompositeException: All promises rejected. in %s:%d
 Stack trace:
-#0 %s/src/Promise.php(%d): React\Promise\{closure}(%S)
+#0 %s/src/Promise.php(%d): %S{closure%S}(%S)
 #1 %s/src/Promise.php(%d): React\Promise\Promise->call(%S)
 #2 %s/src/functions.php(%d): React\Promise\Promise->__construct(%S)
 #3 %s(%d): React\Promise\any(%S)

--- a/tests/FunctionRejectTestFinallyThatThrowsNewExceptionShouldReportUnhandledForNewExceptionOnly.phpt
+++ b/tests/FunctionRejectTestFinallyThatThrowsNewExceptionShouldReportUnhandledForNewExceptionOnly.phpt
@@ -18,8 +18,8 @@ reject(new RuntimeException('foo'))->finally(function (): void {
 --EXPECTF--
 Unhandled promise rejection with RuntimeException: Finally! in %s:%d
 Stack trace:
-#0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
-#1 %s/src/Internal/RejectedPromise.php(%d): React\Promise\Internal\RejectedPromise->React\Promise\Internal\{closure}(%S)
+#0 %s/src/Internal/RejectedPromise.php(%d): {closure%S}(%S)
+#1 %s/src/Internal/RejectedPromise.php(%d): React\Promise\Internal\RejectedPromise->%S{closure%S}(%S)
 #2 %s/src/Internal/RejectedPromise.php(%d): React\Promise\Internal\RejectedPromise->then(%S)
 #3 %s(%d): React\Promise\Internal\RejectedPromise->finally(%S)
 #4 %A{main}

--- a/tests/FunctionRejectTestThenMatchingThatThrowsNewExceptionShouldReportUnhandledRejectionForNewExceptionOnly.phpt
+++ b/tests/FunctionRejectTestThenMatchingThatThrowsNewExceptionShouldReportUnhandledRejectionForNewExceptionOnly.phpt
@@ -18,6 +18,6 @@ reject(new RuntimeException('foo'))->then(null, function () {
 --EXPECTF--
 Unhandled promise rejection with RuntimeException: bar in %s:%d
 Stack trace:
-#0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
+#0 %s/src/Internal/RejectedPromise.php(%d): {closure%S}(%S)
 #1 %s(%d): React\Promise\Internal\RejectedPromise->then(%S)
 #2 %A{main}

--- a/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
+++ b/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
@@ -18,8 +18,8 @@ reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueExcepti
 
 ?>
 --EXPECTF--
-Unhandled promise rejection with TypeError: {closure}(): Argument #1 ($unexpected) must be of type UnexpectedValueException, RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d in %s:%d
+Unhandled promise rejection with TypeError: {closure%S}(): Argument #1 ($unexpected) must be of type UnexpectedValueException, RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d in %s:%d
 Stack trace:
-#0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
+#0 %s/src/Internal/RejectedPromise.php(%d): {closure%S}(%S)
 #1 %s(%d): React\Promise\Internal\RejectedPromise->then(%S)
 #2 %A{main}

--- a/tests/FunctionSetRejectionHandlerThatTriggersErrorHandlerThatThrowsShouldTerminateProgramForUnhandled.phpt
+++ b/tests/FunctionSetRejectionHandlerThatTriggersErrorHandlerThatThrowsShouldTerminateProgramForUnhandled.phpt
@@ -27,9 +27,9 @@ echo 'NEVER';
 --EXPECTF--
 Fatal error: Uncaught OverflowException from unhandled promise rejection handler: This function should never throw in %s:%d
 Stack trace:
-#0 [internal function]: {closure}(%S)
+#0 [internal function]: {closure%S}(%S)
 #1 %s(%d): trigger_error(%S)
-#2 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
+#2 %s/src/Internal/RejectedPromise.php(%d): {closure%S}(%S)
 #3 %s/src/functions.php(%d): React\Promise\Internal\RejectedPromise->__destruct()
 #4 %s(%d): React\Promise\reject(%S)
 #5 %A{main}


### PR DESCRIPTION
This pull request updates hour test suite to improve support with the upcoming PHP 8.4 release. In particular, the new version breaks BC as it changes the stack trace, which we test for in some of our `phpt` files. 

The PHP 8.4 version is currently still in development, hence I didn't add this to our test matrix to avoid any additional PHP 8.4 feature release breaking something. I explained more about this in #260. I can assure that I have tested this with PHP 8.4 and all tests run successfully with my suggested change.

Builds on top of #248, #258, #259, #260 and others