### PR TITLE
Include previous exceptions when reporting unhandled promise rejections

### DIFF
--- a/src/Internal/RejectedPromise.php
+++ b/src/Internal/RejectedPromise.php
@@ -37,8 +37,7 @@ final class RejectedPromise implements PromiseInterface
 
         $handler = set_rejection_handler(null);
         if ($handler === null) {
-            $message = 'Unhandled promise rejection with ' . \get_class($this->reason) . ': ' . $this->reason->getMessage() . ' in ' . $this->reason->getFile() . ':' . $this->reason->getLine() . PHP_EOL;
-            $message .= 'Stack trace:' . PHP_EOL . $this->reason->getTraceAsString();
+            $message = 'Unhandled promise rejection with ' . $this->reason;
 
             \error_log($message);
             return;
@@ -47,8 +46,9 @@ final class RejectedPromise implements PromiseInterface
         try {
             $handler($this->reason);
         } catch (\Throwable $e) {
-            $message = 'Fatal error: Uncaught ' . \get_class($e) . ' from unhandled promise rejection handler: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() . PHP_EOL;
-            $message .= 'Stack trace:' . PHP_EOL . $e->getTraceAsString();
+            \preg_match('/^([^:\s]++)(.*+)$/sm', (string) $e, $match);
+            \assert(isset($match[1], $match[2]));
+            $message = 'Fatal error: Uncaught ' . $match[1] . ' from unhandled promise rejection handler' . $match[2];
 
             \error_log($message);
             exit(255);

--- a/tests/FunctionRejectTestShouldReportUnhandledWithPreviousExceptions.phpt
+++ b/tests/FunctionRejectTestShouldReportUnhandledWithPreviousExceptions.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Calling reject() without any handlers should report unhandled rejection with all previous exceptions
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+reject(new RuntimeException('foo', 42, new \OverflowException('bar', 1000, new \InvalidArgumentException())));
+
+?>
+--EXPECTF--
+Unhandled promise rejection with InvalidArgumentException in %s:%d
+Stack trace:
+#0 %A{main}
+
+Next OverflowException: bar in %s:%d
+Stack trace:
+#0 %A{main}
+
+Next RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}

--- a/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp7.phpt
+++ b/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp7.phpt
@@ -18,7 +18,7 @@ reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueExcepti
 
 ?>
 --EXPECTF--
-Unhandled promise rejection with TypeError: Argument 1 passed to {closure}() must be an instance of UnexpectedValueException, instance of RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d in %s:%d
+Unhandled promise rejection with TypeError: Argument 1 passed to {closure}() must be an instance of UnexpectedValueException, instance of RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d and defined in %s:%d
 Stack trace:
 #0 %s/src/Internal/RejectedPromise.php(%d): {closure}(%S)
 #1 %s(%d): React\Promise\Internal\RejectedPromise->then(%S)

--- a/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
+++ b/tests/FunctionRejectTestThenMismatchThrowsTypeErrorAndShouldReportUnhandledForTypeErrorOnlyOnPhp8.phpt
@@ -18,7 +18,7 @@ reject(new RuntimeException('foo'))->then(null, function (UnexpectedValueExcepti
 
 ?>
 --EXPECTF--
-Unhandled promise rejection with TypeError: {closure%S}(): Argument #1 ($unexpected) must be of type UnexpectedValueException, RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d in %s:%d
+Unhandled promise rejection with TypeError: {closure%S}(): Argument #1 ($unexpected) must be of type UnexpectedValueException, RuntimeException given, called in %s/src/Internal/RejectedPromise.php on line %d and defined in %s:%d
 Stack trace:
 #0 %s/src/Internal/RejectedPromise.php(%d): {closure%S}(%S)
 #1 %s(%d): React\Promise\Internal\RejectedPromise->then(%S)

--- a/tests/FunctionSetRejectionHandlerThatThrowsShouldTerminateProgramForUnhandledWithPreviousExceptions.phpt
+++ b/tests/FunctionSetRejectionHandlerThatThrowsShouldTerminateProgramForUnhandledWithPreviousExceptions.phpt
@@ -1,0 +1,34 @@
+--TEST--
+The callback given to set_rejection_handler() should not throw an exception or the program should terminate for unhandled rejection with all previous exceptions
+--INI--
+# suppress legacy PHPUnit 7 warning for Xdebug 3
+xdebug.default_enable=
+--FILE--
+<?php
+
+use function React\Promise\reject;
+use function React\Promise\set_rejection_handler;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+set_rejection_handler(function (Throwable $e): void {
+    throw new RuntimeException('foo', 42, new \OverflowException('bar', 1000, new \InvalidArgumentException()));
+});
+
+reject(new RuntimeException('foo'));
+
+echo 'NEVER';
+
+?>
+--EXPECTF--
+Fatal error: Uncaught InvalidArgumentException from unhandled promise rejection handler in %s:%d
+Stack trace:
+#0 %A{main}
+
+Next OverflowException: bar in %s:%d
+Stack trace:
+#0 %A{main}
+
+Next RuntimeException: foo in %s:%d
+Stack trace:
+#0 %A{main}


### PR DESCRIPTION
This changeset makes sure we include any previous exceptions when reporting unhandled promise rejections. In particular, instead of reporting a custom message, we now use PHP's default [`Throwable::__toString()`](https://www.php.net/manual/en/throwable.tostring.php) logic which includes the exception type, its message, stack trace and any previous exceptions by default (https://3v4l.org/lBRM1).

Including any previous exceptions makes sense as a default behavior to be in line with PHP's default exception output and to make it easier to track down any unhandled promise rejections. Like previously, this behavior only triggers for any unhandled promise rejections and can be customized by using a global rejection handler as explained in https://github.com/reactphp/promise#set_rejection_handler.

Builds on top of #248 and #249