### PR TITLE
Improve PHP 8.5+ support by avoiding deprecated switch case syntax

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -297,7 +297,7 @@ function _checkTypehint(callable $callback, \Throwable $reason): bool
             break;
         case $type instanceof \ReflectionIntersectionType:
             $isTypeUnion = false;
-        case $type instanceof \ReflectionUnionType;
+        case $type instanceof \ReflectionUnionType:
             $types = $type->getTypes();
             break;
         default:


### PR DESCRIPTION
This must have been a typo, since it's the only instance where the non-standard syntax is used.