### PR TITLE
Run tests on PHP 8.4 and update test environment + use PCOV to avoid segfault with Xdebug 3.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1
@@ -24,7 +25,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
@@ -34,10 +35,11 @@ jobs:
 
   PHPStan:
     name: PHPStan (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">=7.1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.39 || 1.4.10",
+        "phpstan/phpstan": "1.12.19 || 1.4.10",
         "phpunit/phpunit": "^9.6 || ^7.5"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,5 +28,8 @@
         <ini name="assert.active" value="1" />
         <ini name="assert.exception" value="1" />
         <ini name="assert.bail" value="0" />
+        <env name="XDEBUG_MODE" value="off"/>
+        <ini name="pcov.enabled" value="1"/>
+        <ini name="xdebug.mode" value="off"/>
     </php>
 </phpunit>

--- a/src/Internal/FulfilledPromise.php
+++ b/src/Internal/FulfilledPromise.php
@@ -56,9 +56,14 @@ final class FulfilledPromise implements PromiseInterface
         return $this;
     }
 
+    /**
+     * @param callable(): (void|PromiseInterface<void>) $onFulfilledOrRejected
+     * @return PromiseInterface<T>
+     */
     public function finally(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(function ($value) use ($onFulfilledOrRejected): PromiseInterface {
+            /** @var T $value */
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
                 return $value;
             });

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -94,9 +94,14 @@ final class Promise implements PromiseInterface
         });
     }
 
+    /**
+     * @param callable(): (void|PromiseInterface<void>) $onFulfilledOrRejected
+     * @return PromiseInterface<T>
+     */
     public function finally(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(static function ($value) use ($onFulfilledOrRejected): PromiseInterface {
+            /** @var T $value */
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
                 return $value;
             });

--- a/tests/FunctionSetRejectionHandlerThatTriggersDefaultHandlerShouldTerminateProgramForUnhandled.phpt
+++ b/tests/FunctionSetRejectionHandlerThatTriggersDefaultHandlerShouldTerminateProgramForUnhandled.phpt
@@ -21,4 +21,4 @@ echo 'NEVER';
 
 ?>
 --EXPECTF--
-Fatal error: Unexpected RuntimeException: foo in %s line %d
+%AFatal error: Unexpected RuntimeException: foo in %s%s

--- a/tests/FunctionSetRejectionHandlerThatTriggersErrorHandlerThatThrowsShouldTerminateProgramForUnhandled.phpt
+++ b/tests/FunctionSetRejectionHandlerThatTriggersErrorHandlerThatThrowsShouldTerminateProgramForUnhandled.phpt
@@ -27,9 +27,4 @@ echo 'NEVER';
 --EXPECTF--
 Fatal error: Uncaught OverflowException from unhandled promise rejection handler: This function should never throw in %s:%d
 Stack trace:
-#0 [internal function]: {closure%S}(%S)
-#1 %s(%d): trigger_error(%S)
-#2 %s/src/Internal/RejectedPromise.php(%d): {closure%S}(%S)
-#3 %s/src/functions.php(%d): React\Promise\Internal\RejectedPromise->__destruct()
-#4 %s(%d): React\Promise\reject(%S)
-#5 %A{main}
+%A


### PR DESCRIPTION
This PR adds support for PHP 8.4 and modernizes the testing environment. While the initial goal was simply to add PHP 8.4 to the test matrix, several additional improvements were necessary to ensure compatibility.

Builds on top of #260 and #261.
