### PR TITLE
Update PHPStan and fix type annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">=7.1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.39 || 1.4.10",
+        "phpstan/phpstan": "1.12.19 || 1.4.10",
         "phpunit/phpunit": "^9.6 || ^7.5"
     },
     "autoload": {

--- a/src/Internal/FulfilledPromise.php
+++ b/src/Internal/FulfilledPromise.php
@@ -56,9 +56,14 @@ final class FulfilledPromise implements PromiseInterface
         return $this;
     }
 
+    /**
+     * @param callable(): (void|PromiseInterface<void>) $onFulfilledOrRejected
+     * @return PromiseInterface<T>
+     */
     public function finally(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(function ($value) use ($onFulfilledOrRejected): PromiseInterface {
+        	/** @var T $value */
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
                 return $value;
             });

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -94,9 +94,14 @@ final class Promise implements PromiseInterface
         });
     }
 
+    /**
+     * @param callable(): (void|PromiseInterface<void>) $onFulfilledOrRejected
+     * @return PromiseInterface<T>
+     */
     public function finally(callable $onFulfilledOrRejected): PromiseInterface
     {
         return $this->then(static function ($value) use ($onFulfilledOrRejected): PromiseInterface {
+        	/** @var T $value */
             return resolve($onFulfilledOrRejected())->then(function () use ($value) {
                 return $value;
             });


### PR DESCRIPTION
The updated PHPStan version provides improved type checking capabilities. The added type annotations resolve static analysis warnings and improve code documentation, making the generic type flow more explicit in the finally() method implementations.

Builds on top of #251.

This PR breaks down #266 into smaller parts. 