### PR TITLE
[2.x] Improve PHP 8.5+ support by avoiding deprecated switch case syntax

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -366,7 +366,7 @@ function _checkTypehint(callable $callback, $object)
             break;
         case $type instanceof \ReflectionIntersectionType:
             $isTypeUnion = false;
-        case $type instanceof \ReflectionUnionType;
+        case $type instanceof \ReflectionUnionType:
             $types = $type->getTypes();
             break;
         default:


### PR DESCRIPTION
This builds on top of #264 porting that change to v2.